### PR TITLE
feat: expose token usage in call_local_llm tool response

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,15 @@ git tag가 없으면 `version=dev`.
 - **MCP 에러 반환** — 도구 레벨 에러는 `log.Fatal`이 아닌 `CallToolResult{IsError: true}`로 반환한다.
 - **변경 시 README.md 필수 업데이트** — 환경변수 추가/변경, 동작 변경, 설정 예시 변경 시 반드시 README.md의 Configuration 표와 Usage 예시를 함께 수정한다.
 
+## 개발 워크플로우
+
+코드 변경은 항상 아래 순서를 따른다:
+
+1. **GitHub issue 생성** — 영어로, 변경 동기와 구체적 구현 방향 포함
+2. **브랜치 생성** — `feat/issue-{N}-{short-desc}` 또는 `fix/issue-{N}-{short-desc}` 형식으로 `develop`에서 분기
+3. **브랜치에서 작업** 후 커밋
+4. **PR 생성** — 이슈 번호 연결 (`Closes #N`)
+
 ## Adding a new MCP tool
 
 1. 필요하면 `internal/` 아래에 새 패키지 또는 함수 추가

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -82,15 +82,17 @@ func main() {
 			}, nil, nil
 		}
 
-		text, err := client.Call(ctx, in)
+		text, usage, err := client.Call(ctx, in)
 		if err != nil {
 			return &mcp.CallToolResult{
 				IsError: true,
 				Content: []mcp.Content{&mcp.TextContent{Text: err.Error()}},
 			}, nil, nil
 		}
+		result := text + fmt.Sprintf("\n\n[usage: prompt=%d, completion=%d, total=%d]",
+			usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
 		return &mcp.CallToolResult{
-			Content: []mcp.Content{&mcp.TextContent{Text: text}},
+			Content: []mcp.Content{&mcp.TextContent{Text: result}},
 		}, nil, nil
 	})
 

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -30,6 +30,12 @@ type chatRequest struct {
 	MaxTokens int           `json:"max_tokens"`
 }
 
+type Usage struct {
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+
 type chatResponse struct {
 	Choices []struct {
 		Message struct {
@@ -39,6 +45,7 @@ type chatResponse struct {
 	Error *struct {
 		Message string `json:"message"`
 	} `json:"error,omitempty"`
+	Usage Usage `json:"usage"`
 }
 
 type Client struct {
@@ -66,13 +73,13 @@ func NewClient(baseURL, model string, maxTokens int, timeout time.Duration, maxC
 	}
 }
 
-func (c *Client) Call(ctx context.Context, in *Input) (string, error) {
+func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 	if c.sem != nil {
 		select {
 		case c.sem <- struct{}{}:
 			defer func() { <-c.sem }()
 		case <-ctx.Done():
-			return "", ctx.Err()
+			return "", Usage{}, ctx.Err()
 		}
 	}
 	messages := []chatMessage{}
@@ -92,39 +99,39 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, error) {
 
 	body, err := json.Marshal(chatRequest{Model: model, Messages: messages, MaxTokens: maxTokens})
 	if err != nil {
-		return "", fmt.Errorf("marshal failed: %w", err)
+		return "", Usage{}, fmt.Errorf("marshal failed: %w", err)
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
 	if err != nil {
-		return "", fmt.Errorf("create request failed: %w", err)
+		return "", Usage{}, fmt.Errorf("create request failed: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("request failed: %w", err)
+		return "", Usage{}, fmt.Errorf("request failed: %w", err)
 	}
 	defer resp.Body.Close()
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("read response failed: %w", err)
+		return "", Usage{}, fmt.Errorf("read response failed: %w", err)
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
+		return "", Usage{}, fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
 	}
 
 	var result chatResponse
 	if err := json.Unmarshal(raw, &result); err != nil {
-		return "", fmt.Errorf("parse failed: %w", err)
+		return "", Usage{}, fmt.Errorf("parse failed: %w", err)
 	}
 	if result.Error != nil {
-		return "", fmt.Errorf("API error: %s", result.Error.Message)
+		return "", Usage{}, fmt.Errorf("API error: %s", result.Error.Message)
 	}
 	if len(result.Choices) == 0 {
-		return "", fmt.Errorf("empty response")
+		return "", Usage{}, fmt.Errorf("empty response")
 	}
-	return result.Choices[0].Message.Content, nil
+	return result.Choices[0].Message.Content, result.Usage, nil
 }


### PR DESCRIPTION
Closes #3

## Summary
- Parse `usage` fields (`prompt_tokens`, `completion_tokens`, `total_tokens`) from vllm-mlx API response
- Append `[usage: prompt=N, completion=N, total=N]` to every `call_local_llm` tool response
- Add issue → branch → PR workflow rule to `CLAUDE.md`

## Changes
- `internal/llm/client.go` — add `Usage` struct, parse from `chatResponse`, change `Call` return to `(string, Usage, error)`
- `cmd/mcp-local-llm/main.go` — append usage summary to tool response text
- `CLAUDE.md` — add development workflow section

## Test plan
- [ ] `make build` 빌드 확인
- [ ] `call_local_llm` 호출 시 응답 끝에 `[usage: prompt=N, completion=N, total=N]` 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)