### PR TITLE
feat: add thinking block filtering with per-call override

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ All settings are controlled via environment variables. The binary has no config 
 | `LOCAL_LLM_MAX_TOKENS` | `32768` | Default maximum output tokens |
 | `LOCAL_LLM_TIMEOUT_SECONDS` | `300` | HTTP request timeout in seconds |
 | `LOCAL_LLM_MAX_CONCURRENT` | `0` (unlimited) | Max concurrent requests to the LLM server (recommended: `2`) |
+| `LOCAL_LLM_FILTER_THINKING` | `true` | Strip `<\|channel>thought...<channel\|>` thinking blocks from responses. Can be overridden per-call via the `filter_thinking` parameter. |
 
 Copy `.env.example` to `.env` for reference (the binary itself reads from the process environment, not a file).
 
@@ -72,6 +73,7 @@ Calls the local LLM and returns its response as plain text. Each response includ
 | `system` | no | System prompt (prepended before the user message) |
 | `model` | no | Override the default model for this call |
 | `max_tokens` | no | Override the default token limit for this call |
+| `filter_thinking` | no | Override server-level thinking block filtering for this call (`true` = filter, `false` = keep). Omit to use the server default (`LOCAL_LLM_FILTER_THINKING`). |
 
 **Recommended use cases**
 

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -122,7 +122,8 @@ func main() {
 		}
 	}
 
-	client := llm.NewClient(baseURL, model, maxTokens, timeout, maxConcurrent)
+	filterThinking := envOr("LOCAL_LLM_FILTER_THINKING", "true") != "false"
+	client := llm.NewClient(baseURL, model, maxTokens, timeout, maxConcurrent, filterThinking)
 
 	usagePath, err := usageFilePath()
 	if err != nil {

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -7,16 +7,21 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 )
+
+var thinkingRe = regexp.MustCompile(`(?s)<\|channel>thought.*?<channel\|>`)
 
 const defaultTimeout = 5 * time.Minute
 
 type Input struct {
-	Prompt    string `json:"prompt"               jsonschema:"LLM에 전달할 사용자 메시지,required"`
-	System    string `json:"system,omitempty"     jsonschema:"시스템 프롬프트 (선택사항)"`
-	Model     string `json:"model,omitempty"      jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
-	MaxTokens int    `json:"max_tokens,omitempty" jsonschema:"최대 출력 토큰 수 (기본값: 32768)"`
+	Prompt         string `json:"prompt"                    jsonschema:"LLM에 전달할 사용자 메시지,required"`
+	System         string `json:"system,omitempty"          jsonschema:"시스템 프롬프트 (선택사항)"`
+	Model          string `json:"model,omitempty"           jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
+	MaxTokens      int    `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (기본값: 32768)"`
+	FilterThinking *bool  `json:"filter_thinking,omitempty" jsonschema:"thinking 블록 필터링 여부 (true=필터, false=유지). 생략 시 서버 기본값(LOCAL_LLM_FILTER_THINKING) 적용"`
 }
 
 type chatMessage struct {
@@ -52,11 +57,12 @@ type Client struct {
 	BaseURL          string
 	DefaultModel     string
 	DefaultMaxTokens int
+	FilterThinking   bool
 	httpClient       *http.Client
 	sem              chan struct{} // nil = 무제한
 }
 
-func NewClient(baseURL, model string, maxTokens int, timeout time.Duration, maxConcurrent int) *Client {
+func NewClient(baseURL, model string, maxTokens int, timeout time.Duration, maxConcurrent int, filterThinking bool) *Client {
 	if timeout <= 0 {
 		timeout = defaultTimeout
 	}
@@ -68,6 +74,7 @@ func NewClient(baseURL, model string, maxTokens int, timeout time.Duration, maxC
 		BaseURL:          baseURL,
 		DefaultModel:     model,
 		DefaultMaxTokens: maxTokens,
+		FilterThinking:   filterThinking,
 		httpClient:       &http.Client{Timeout: timeout},
 		sem:              sem,
 	}
@@ -133,5 +140,13 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 	if len(result.Choices) == 0 {
 		return "", Usage{}, fmt.Errorf("empty response")
 	}
-	return result.Choices[0].Message.Content, result.Usage, nil
+	content := result.Choices[0].Message.Content
+	filterThinking := c.FilterThinking
+	if in.FilterThinking != nil {
+		filterThinking = *in.FilterThinking
+	}
+	if filterThinking {
+		content = strings.TrimSpace(thinkingRe.ReplaceAllString(content, ""))
+	}
+	return content, result.Usage, nil
 }


### PR DESCRIPTION
## Summary

- Added `LOCAL_LLM_FILTER_THINKING` env var (default: `true`) as server-level default for filtering `<|channel>thought...<channel|>` thinking blocks from Gemma 4 responses
- Added `filter_thinking *bool` parameter to `call_local_llm` tool — Claude can override per-call (`true`=filter, `false`=keep, omit=use server default)
- Filtering applied in `internal/llm/client.go` via compiled regex before returning content
- Updated README: configuration table and `call_local_llm` parameter table

Closes #10

## Test plan

- [ ] Build succeeds: `make build`
- [ ] Default behavior: thinking blocks stripped from response
- [ ] `filter_thinking: false` per-call keeps thinking blocks
- [ ] `LOCAL_LLM_FILTER_THINKING=false` server default keeps thinking blocks
- [ ] No-thinking response passes through unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)