### PR TITLE
fix: omit max_tokens from requests when not explicitly set

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ All settings are controlled via environment variables. The binary has no config 
 |---|---|---|
 | `LOCAL_LLM_BASE_URL` | `http://localhost:8000` | Base URL of the local LLM server |
 | `LOCAL_LLM_MODEL` | `mlx-community/gemma-4-26b-a4b-it-4bit` | Model name passed to the server |
-| `LOCAL_LLM_MAX_TOKENS` | `32768` | Default maximum output tokens |
+| `LOCAL_LLM_MAX_TOKENS` | — | Cap on output tokens per request. If unset, `max_tokens` is omitted and the server decides. |
 | `LOCAL_LLM_TIMEOUT_SECONDS` | `300` | HTTP request timeout in seconds |
 | `LOCAL_LLM_MAX_CONCURRENT` | `0` (unlimited) | Max concurrent requests to the LLM server (recommended: `2`) |
 | `LOCAL_LLM_FILTER_THINKING` | `true` | Strip `<\|channel>thought...<channel\|>` thinking blocks from responses. Can be overridden per-call via the `filter_thinking` parameter. |
@@ -51,7 +51,6 @@ Add the following to your `claude_desktop_config.json`:
       "env": {
         "LOCAL_LLM_BASE_URL": "http://localhost:8000",
         "LOCAL_LLM_MODEL": "mlx-community/gemma-4-26b-a4b-it-4bit",
-        "LOCAL_LLM_MAX_TOKENS": "32768",
         "LOCAL_LLM_MAX_CONCURRENT": "2"
       }
     }

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -22,9 +22,8 @@ var (
 )
 
 const (
-	defaultBaseURL   = "http://localhost:8000"
-	defaultModel     = "mlx-community/gemma-4-26b-a4b-it-4bit"
-	defaultMaxTokens = 32768
+	defaultBaseURL = "http://localhost:8000"
+	defaultModel   = "mlx-community/gemma-4-26b-a4b-it-4bit"
 )
 
 type usageStats struct {
@@ -101,7 +100,7 @@ func main() {
 	baseURL := envOr("LOCAL_LLM_BASE_URL", defaultBaseURL)
 	model := envOr("LOCAL_LLM_MODEL", defaultModel)
 
-	maxTokens := defaultMaxTokens
+	maxTokens := 0
 	if v := os.Getenv("LOCAL_LLM_MAX_TOKENS"); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
 			maxTokens = n

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -20,7 +20,7 @@ type Input struct {
 	Prompt         string `json:"prompt"                    jsonschema:"LLM에 전달할 사용자 메시지,required"`
 	System         string `json:"system,omitempty"          jsonschema:"시스템 프롬프트 (선택사항)"`
 	Model          string `json:"model,omitempty"           jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
-	MaxTokens      int    `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (기본값: 32768)"`
+	MaxTokens      int    `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (생략 시 서버 기본값 사용)"`
 	FilterThinking *bool  `json:"filter_thinking,omitempty" jsonschema:"thinking 블록 필터링 여부 (true=필터, false=유지). 생략 시 서버 기본값(LOCAL_LLM_FILTER_THINKING) 적용"`
 }
 
@@ -32,7 +32,7 @@ type chatMessage struct {
 type chatRequest struct {
 	Model     string        `json:"model"`
 	Messages  []chatMessage `json:"messages"`
-	MaxTokens int           `json:"max_tokens"`
+	MaxTokens *int          `json:"max_tokens,omitempty"`
 }
 
 type Usage struct {
@@ -99,9 +99,13 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 	if model == "" {
 		model = c.DefaultModel
 	}
-	maxTokens := in.MaxTokens
-	if maxTokens <= 0 {
-		maxTokens = c.DefaultMaxTokens
+	var maxTokens *int
+	if in.MaxTokens > 0 {
+		v := in.MaxTokens
+		maxTokens = &v
+	} else if c.DefaultMaxTokens > 0 {
+		v := c.DefaultMaxTokens
+		maxTokens = &v
 	}
 
 	body, err := json.Marshal(chatRequest{Model: model, Messages: messages, MaxTokens: maxTokens})


### PR DESCRIPTION
## Summary

- Changed `chatRequest.MaxTokens` from `int` to `*int` with `omitempty` — `max_tokens` is now omitted from the HTTP request when not set
- In `Call()`, `max_tokens` is only populated when the caller explicitly sets `Input.MaxTokens > 0`, or when the admin sets `LOCAL_LLM_MAX_CONCURRENT` via `LOCAL_LLM_MAX_TOKENS` env var
- Removed hardcoded `defaultMaxTokens = 32768` constant — `LOCAL_LLM_MAX_TOKENS` is now a true opt-in cap with no built-in default
- Updated README: `LOCAL_LLM_MAX_TOKENS` default changed from `32768` to `—`, removed it from the Claude Desktop config example

Closes #12

## Test plan

- [ ] Build succeeds: `make build`
- [ ] Request without `max_tokens` set → no `max_tokens` field in HTTP body
- [ ] Request with `Input.MaxTokens = 1024` → `"max_tokens": 1024` in HTTP body
- [ ] `LOCAL_LLM_MAX_TOKENS=4096` env var → `"max_tokens": 4096` in HTTP body

🤖 Generated with [Claude Code](https://claude.com/claude-code)