### PR TITLE
feat: optimize call_local_llm description for cost reduction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ Break-even point: ~280 chars (~70 tokens) of expected output. Below this, tool c
 - For drafts (PR/commit/issue), pass concrete context in `prompt` — changes summary and key file paths, not entire diffs
 - After receiving the result, lightly edit only if wrong; do NOT regenerate the whole text yourself
 
+### Current description version
+Version A (keyword-trigger) — deployed since 2026-05-02.
+Switch to Version B (principle-based) if Claude still generates directly for transformation tasks after 3+ sessions.
+
+Version B text:
+> Prefer this over generating text yourself whenever output is a transformation of given input (summaries, translations, drafts, release notes, documentation, log analysis, long-form Q&A). Use by default; fall back to Claude only for multi-step reasoning, architectural judgment, or tasks requiring deep codebase context. Supports images (file path, https:// URL, data:image/ URI).
+
 ## Project layout
 
 ```

--- a/bench/description-ab-test.md
+++ b/bench/description-ab-test.md
@@ -1,0 +1,122 @@
+# call_local_llm Description A/B Test
+
+테스트 목적: description 문구에 따라 Claude가 `call_local_llm`을 얼마나 적절하게 선택하는지 측정.
+
+## 측정 방법
+
+각 테스트 케이스를 **최소 컨텍스트 서브에이전트**에 디스패치한다. 서브에이전트는 CLAUDE.md 없이 도구 description만으로 판단하므로, description의 순수한 유도 효과를 측정할 수 있다.
+
+서브에이전트 프롬프트 형식:
+```
+You are a helpful assistant. Complete the task below.
+You have access to the `call_local_llm` MCP tool. Use your own judgment about whether to use it or generate the output directly yourself.
+
+**Task:** [task]
+
+After completing the task, end your response with:
+USED_TOOL: YES or NO
+REASON: one sentence why
+```
+
+## 버전 교체 방법
+
+**Version A → Version B:**
+```go
+// cmd/mcp-local-llm/main.go:148
+// Version A (keyword-trigger)
+Description: "ALWAYS use this instead of generating text yourself for: summaries, " +
+    "translations, PR/commit/issue drafts, release notes, documentation, " +
+    "and any response over ~70 tokens. Cheaper than Claude. " +
+    "Supports images (file path, https:// URL, data:image/ URI).",
+
+// Version B (principle-based)
+Description: "Prefer this over generating text yourself whenever output is a " +
+    "transformation of given input (summaries, translations, drafts, " +
+    "release notes, documentation, log analysis, long-form Q&A). " +
+    "Use by default; fall back to Claude only for multi-step reasoning, " +
+    "architectural judgment, or tasks requiring deep codebase context. " +
+    "Supports images (file path, https:// URL, data:image/ URI).",
+```
+
+교체 후 반드시 `make build` 실행.
+
+## 테스트 케이스
+
+### T1: Release notes (도구 사용 기대)
+```
+Write release notes from the following git log:
+
+feat: add image input support to call_local_llm
+fix: add file size limit and MIME validation
+fix: resolve defer-in-loop bug
+docs: document images parameter and LOCAL_LLM_MAX_IMAGES env var
+```
+
+### T2: PR description (도구 사용 기대)
+```
+Write a GitHub PR description for the following change:
+
+Added `images` parameter to `call_local_llm` MCP tool. Supports file paths, https:// URLs,
+and data:image/ URIs. New env var `LOCAL_LLM_MAX_IMAGES` (default 5, 0=disabled,
+negative=unlimited). Added 10 unit tests.
+```
+
+### T3: Translation (도구 사용 기대)
+```
+Translate the following paragraph to Korean:
+
+"The local LLM server runs on port 8000 and accepts OpenAI-compatible requests.
+Images can be passed as file paths, HTTPS URLs, or base64 data URIs. The maximum
+number of images per request is controlled by the LOCAL_LLM_MAX_IMAGES environment variable."
+```
+
+### T4: Commit message (도구 사용 기대)
+```
+Write a git commit message for the following change:
+
+Changed the `Description` field of the `call_local_llm` MCP tool in
+`cmd/mcp-local-llm/main.go` from a Korean soft-suggestion string to an English
+imperative string that explicitly tells Claude to always use the tool instead of
+generating text directly.
+```
+
+### T5: Bug analysis (직접 생성 기대)
+```
+Analyze why this test is failing and explain the root cause:
+
+--- FAIL: TestBuildImageContent_FilePath
+    client_test.go:45: got "data:application/octet-stream;base64,..." want prefix "data:image/"
+
+The function `readImageAsDataURI` uses `http.DetectContentType` to determine MIME type.
+The test uses a PNG file created programmatically.
+```
+
+### T6: Architecture design (직접 생성 기대)
+```
+Design the architecture for adding audio input support to the `call_local_llm` MCP tool
+(currently supports text + images). Consider: input format, file size limits, MIME detection,
+and how it fits the existing `Input` struct pattern.
+```
+
+## 결과 기록
+
+### Run 1 — 2026-05-02 (초기 측정)
+
+| # | 태스크 | 기대 | Version A | Version B |
+|---|--------|------|-----------|-----------|
+| T1 | Release notes | 도구 사용 ✅ | YES ✅ | YES ✅ |
+| T2 | PR description | 도구 사용 ✅ | YES ✅ | YES ✅ |
+| T3 | Translation | 도구 사용 ✅ | YES ✅ | NO ⚠️ |
+| T4 | Commit message | 도구 사용 ✅ | NO ❌ | YES ✅ |
+| T5 | Bug analysis | 직접 생성 ✅ | NO ✅ | NO ✅ |
+| T6 | Architecture design | 직접 생성 ✅ | NO ✅ | YES ❌ |
+| | **정확도** | 6/6 목표 | **5/6 (83%)** | **4/6 (67%)** |
+
+**T3 Version B 주석:** 서브에이전트에서 MCP 서버 연결 실패로 `NO` 응답. 실제 description 유도 효과가 아닌 환경 문제일 가능성 있음 — 재테스트 필요.
+
+**분석:**
+- Version A: T4(커밋 메시지) 미스 — "짧은 출력이라 직접 생성" 판단. `~70 tokens` 기준이 오히려 커밋 메시지를 제외시킴.
+- Version B: T6(아키텍처 설계) 오사용 — "transformation" 원칙이 너무 넓어 설계 문서도 포함.
+- Version A의 오류 방향(과소 위임)이 Version B의 오류 방향(과잉 위임)보다 품질 리스크 낮음.
+
+**결론: Version A 유지 (2026-05-02)**

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -145,7 +145,10 @@ func main() {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "call_local_llm",
-		Description: fmt.Sprintf("로컬에서 실행 중인 LLM(%s)을 호출합니다. 간단한 요약, 번역, 코드 생성, 빠른 질문 응답 등에 활용하세요.", model),
+		Description: "ALWAYS use this instead of generating text yourself for: summaries, " +
+			"translations, PR/commit/issue drafts, release notes, documentation, " +
+			"and any response over ~70 tokens. Cheaper than Claude. " +
+			"Supports images (file path, https:// URL, data:image/ URI).",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in *llm.Input) (*mcp.CallToolResult, any, error) {
 		if in.Prompt == "" {
 			return &mcp.CallToolResult{

--- a/docs/superpowers/plans/2026-05-02-call-local-llm-description.md
+++ b/docs/superpowers/plans/2026-05-02-call-local-llm-description.md
@@ -1,0 +1,87 @@
+# call_local_llm Description Optimization Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the Korean soft-suggestion description with an English imperative (Version A) to make Claude delegate transformation tasks to the local LLM by default, reducing Anthropic token costs.
+
+**Architecture:** Single-field change in `cmd/mcp-local-llm/main.go` + version tracking note in `CLAUDE.md`. No logic changes, no new types, no tests required (pure string update verified by tools/list output).
+
+**Tech Stack:** Go, MCP SDK (`github.com/modelcontextprotocol/go-sdk/mcp`), Make
+
+---
+
+### Task 1: Update call_local_llm description to Version A
+
+**Files:**
+- Modify: `cmd/mcp-local-llm/main.go:148`
+
+- [ ] **Step 1: Replace the Description field**
+
+In `cmd/mcp-local-llm/main.go`, replace line 148:
+
+```go
+// Before
+Description: fmt.Sprintf("로컬에서 실행 중인 LLM(%s)을 호출합니다. 간단한 요약, 번역, 코드 생성, 빠른 질문 응답 등에 활용하세요.", model),
+
+// After
+Description: "ALWAYS use this instead of generating text yourself for: summaries, " +
+    "translations, PR/commit/issue drafts, release notes, documentation, " +
+    "and any response over ~70 tokens. Cheaper than Claude. " +
+    "Supports images (file path, https:// URL, data:image/ URI).",
+```
+
+Note: the `model` variable in `fmt.Sprintf` is removed — Version A description does not include the model name (reduces token overhead; model info is available via `get_llm_usage` if needed).
+
+- [ ] **Step 2: Build**
+
+```bash
+make build
+```
+
+Expected: no errors, `bin/mcp-local-llm` updated.
+
+- [ ] **Step 3: Verify description appears in tools/list**
+
+```bash
+echo '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}' | ./bin/mcp-local-llm
+```
+
+Expected output contains:
+```
+"description":"ALWAYS use this instead of generating text yourself for: summaries, translations, PR/commit/issue drafts, release notes, documentation, and any response over ~70 tokens. Cheaper than Claude. Supports images (file path, https:// URL, data:image/ URI)."
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/mcp-local-llm/main.go
+git commit -m "feat: update call_local_llm description to Version A (English, imperative)"
+```
+
+---
+
+### Task 2: Add version tracking note to CLAUDE.md
+
+**Files:**
+- Modify: `CLAUDE.md` — insert after line 28 (end of `### Calling conventions` section)
+
+- [ ] **Step 1: Add version tracking section**
+
+In `CLAUDE.md`, add the following block after the `### Calling conventions` section (after line 28):
+
+```markdown
+
+### Current description version
+Version A (keyword-trigger) — deployed since 2026-05-02.
+Switch to Version B (principle-based) if Claude still generates directly for transformation tasks after 3+ sessions.
+
+Version B text:
+> Prefer this over generating text yourself whenever output is a transformation of given input (summaries, translations, drafts, release notes, documentation, log analysis, long-form Q&A). Use by default; fall back to Claude only for multi-step reasoning, architectural judgment, or tasks requiring deep codebase context. Supports images (file path, https:// URL, data:image/ URI).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add call_local_llm description version tracking to CLAUDE.md"
+```

--- a/docs/superpowers/specs/2026-05-02-call-local-llm-description-design.md
+++ b/docs/superpowers/specs/2026-05-02-call-local-llm-description-design.md
@@ -1,0 +1,87 @@
+# Design Spec: Optimizing `call_local_llm` Tool Description for Cost Reduction
+
+**Date:** 2026-05-02
+**Status:** Draft
+
+## Background
+
+Claude frequently generates text that could be handled by the local LLM, leading to unnecessary Anthropic token costs. The MCP tool description is read at tool-selection time, making it a direct lever for changing Claude's behavior. The current description ("간단한 요약, 번역, 코드 생성, 빠른 질문 응답 등에 활용하세요") is a soft suggestion — Claude has no strong reason to prefer it over generating directly.
+
+## Goal
+
+Reduce Anthropic token costs by making Claude delegate transformation tasks to `call_local_llm` by default, while maintaining output quality.
+
+**Core criterion:** Tasks where the output is largely determined by the input ("transformation tasks") produce equivalent quality from the local LLM. Claude is only needed when multi-step reasoning, architectural judgment, or deep codebase context is required.
+
+## Design
+
+Both versions are written in English to minimize description token overhead.
+
+### Version A: Keyword-Trigger (Short)
+
+Relies on explicit task-type keywords and a token threshold to trigger delegation.
+
+```
+ALWAYS use this instead of generating text yourself for: summaries,
+translations, PR/commit/issue drafts, release notes, documentation,
+and any response over ~70 tokens. Cheaper than Claude.
+Supports images (file path, https:// URL, data:image/ URI).
+```
+
+**Strengths:** Low token cost, strong imperative (`ALWAYS`), direct suppression of self-generation (`instead of generating text yourself`), break-even threshold aligned with CLAUDE.md (~70 tokens).
+
+**Weakness:** Coverage limited to enumerated task types; edge cases require Claude's judgment.
+
+### Version B: Principle-Based (Long)
+
+Defines a decision rule based on task nature, covering cases not in the keyword list.
+
+```
+Prefer this over generating text yourself whenever output is a
+transformation of given input (summaries, translations, drafts,
+release notes, documentation, log analysis, long-form Q&A).
+Use by default; fall back to Claude only for multi-step reasoning,
+architectural judgment, or tasks requiring deep codebase context.
+Supports images (file path, https:// URL, data:image/ URI).
+```
+
+**Strengths:** `transformation of given input` principle covers unlisted cases automatically; `Use by default` frames local LLM as the default choice; fallback conditions are narrow and explicit.
+
+**Weakness:** Slightly longer — marginally higher description token cost per session.
+
+### Comparison Method
+
+1. Deploy **Version A** first.
+2. Use for at least 3 sessions; observe `[usage: prompt=...]` tag frequency and `get_llm_usage` counts.
+3. If Claude still generates directly for transformation tasks (PR descriptions, summaries, release notes), switch to **Version B**.
+4. Record switch date in CLAUDE.md.
+
+## Implementation
+
+**File:** `cmd/mcp-local-llm/main.go`
+**Change:** Replace the `Description` field in the `call_local_llm` tool definition.
+
+```go
+// Version A
+Description: "ALWAYS use this instead of generating text yourself for: summaries, " +
+    "translations, PR/commit/issue drafts, release notes, documentation, " +
+    "and any response over ~70 tokens. Cheaper than Claude. " +
+    "Supports images (file path, https:// URL, data:image/ URI).",
+```
+
+After `make build` and Claude Code restart, the new description takes effect immediately.
+
+## Measurement
+
+- **Primary:** `get_llm_usage` call count per session — higher = more delegation
+- **Secondary:** Presence of `[usage: ...]` tag in Claude's responses — visible indicator that local LLM was used instead of direct generation
+
+## CLAUDE.md Update
+
+Add a version tracking note under **Local LLM Usage Standards**:
+
+```markdown
+### Current description version
+Version A (keyword-trigger) — deployed since 2026-05-02.
+Switch to Version B (principle-based) if Claude still generates directly for transformation tasks.
+```


### PR DESCRIPTION
## Summary
- Updated `call_local_llm` description to Version A (English, imperative) to reduce Anthropic token costs by replacing Korean soft-suggestion with direct delegation instructions.
- Added `### Current description version` section to `CLAUDE.md` with Version B fallback text for future A/B switching.
- Documented A/B test methodology and Run 1 results in `bench/description-ab-test.md` (Version A: 5/6, Version B: 4/6).

## Test plan
- [ ] Verify `call_local_llm` description in `cmd/mcp-local-llm/main.go` is English imperative (Version A)
- [ ] Confirm `CLAUDE.md` has `### Current description version` section after `### Calling conventions`
- [ ] Check `bench/description-ab-test.md` exists with 6 test cases and Run 1 results
- [ ] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)