### PR TITLE
feat: retry on transient errors (issue #21)

### DIFF
--- a/docs/VLLM_API.md
+++ b/docs/VLLM_API.md
@@ -1,0 +1,526 @@
+# vllm-mlx API Spec
+
+> Base URL: `http://localhost:8000`  
+> 인증: 기본 비활성화. `--api-key` 옵션으로 활성화 시 `Authorization: Bearer <key>` 또는 `x-api-key: <key>` 헤더 필요.
+
+---
+
+## 목차
+
+- [API와 도구 연결](#api와-도구-연결)
+- [시스템](#시스템)
+- [모델](#모델)
+- [채팅 (OpenAI)](#채팅-openai)
+- [채팅 (Anthropic)](#채팅-anthropic)
+- [Responses (OpenAI)](#responses-openai)
+- [텍스트 완성](#텍스트-완성)
+- [STT (음성 인식)](#stt-음성-인식)
+- [TTS (음성 합성)](#tts-음성-합성)
+- [MCP](#mcp)
+- [임베딩](#임베딩)
+- [재순위](#재순위)
+- [캐시](#캐시)
+
+---
+
+## API와 도구 연결
+
+vllm-mlx **HTTP API**와 **MCP 도구**가 어떻게 연결되는지 정리한다. (여기서 “도구”는 Cursor/Claude 등에 붙는 MCP `tools/list`의 항목과, 채팅 요청의 OpenAI `tools` 배열을 모두 포함한다.)
+
+### mcp-local-llm MCP 서버 → vllm-mlx
+
+에디터·에이전트가 **mcp-local-llm** 바이너리를 MCP 서버로 쓸 때, 각 MCP 도구가 가리키는 vllm-mlx 호출은 아래와 같다.
+
+| MCP 도구 | 호출하는 vllm-mlx API | 비고 |
+|----------|----------------------|------|
+| `call_local_llm` | `POST /v1/chat/completions` | OpenAI Chat Completions JSON (`model`, `messages`, 선택 `max_tokens`). Base URL은 환경 변수 `LOCAL_LLM_BASE_URL` (미설정 시 `http://localhost:8000`). |
+| `get_llm_usage` | — | vllm-mlx를 호출하지 않음. 바이너리와 같은 디렉터리의 `usage.json`만 읽고 갱신. |
+
+`call_local_llm`은 **`/v1/mcp/*` MCP 프록시 API를 거치지 않는다.**
+
+### 채팅 API의 function calling (`tools` 필드)
+
+클라이언트가 `POST /v1/chat/completions` 본문에 `tools` / `tool_choice`를 넣으면, 모델 응답에 `tool_calls` 등이 포함될 수 있다. **도구 정의의 실행(HTTP 콜백 등)은 vllm-mlx가 아니라 요청을 보낸 클라이언트**가 처리하는 일반적인 OpenAI 호환 흐름이다.
+
+| API | 요청에서 도구 관련 필드 | 역할 |
+|-----|-------------------------|------|
+| `POST /v1/chat/completions` | `tools`, `tool_choice` | 스키마에 맞는 **모델 출력** 유도. 실제 외부 도구 실행은 클라이언트 책임. |
+
+### vllm-mlx MCP 프록시 → 연동 MCP 서버
+
+vllm-mlx에 **별도 MCP 서버**가 연결되어 있을 때, 아래 HTTP로 그 서버들의 도구를 조회·실행한다. (mcp-local-llm과는 독립된 경로.)
+
+| vllm-mlx API | 도구(MCP) 연결 관점에서의 역할 |
+|--------------|--------------------------------|
+| `GET /v1/mcp/tools` | 연결된 MCP 서버가 노출하는 도구 목록 (`name`, `description`, `server` 등). |
+| `GET /v1/mcp/servers` | 연결된 MCP 서버 목록. |
+| `POST /v1/mcp/execute` | `server`, `tool`, `arguments`로 **해당 MCP 도구를 HTTP에서 직접 실행**. |
+
+---
+
+## 시스템
+
+### `GET /health`
+서버 상태 확인.
+
+**응답:**
+```json
+{"status": "ok"}
+```
+
+### `GET /metrics`
+Prometheus 형식 메트릭.
+
+### `GET /v1/status`
+모델 로드 상태, 설정 정보.
+
+---
+
+## 모델
+
+### `GET /v1/models`
+로드된 모델 목록.
+
+**응답:**
+```json
+{
+  "object": "list",
+  "data": [
+    {"id": "mlx-community/gemma-4-26b-a4b-it-4bit", "object": "model"}
+  ]
+}
+```
+
+---
+
+## 채팅 (OpenAI)
+
+### `POST /v1/chat/completions`
+
+OpenAI Chat Completions API 호환.
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "messages": [
+    {"role": "system", "content": "You are a helpful assistant."},
+    {"role": "user", "content": "안녕하세요!"}
+  ],
+  "max_tokens": 500,
+  "temperature": 0.7,
+  "stream": false
+}
+```
+
+**멀티모달 (이미지 포함):**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "messages": [{
+    "role": "user",
+    "content": [
+      {"type": "text", "text": "이 이미지를 설명해줘"},
+      {"type": "image_url", "image_url": {"url": "https://..."}}
+    ]
+  }],
+  "max_tokens": 300
+}
+```
+
+**Tool Calling:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "messages": [{"role": "user", "content": "서울 날씨 알려줘"}],
+  "tools": [{
+    "type": "function",
+    "function": {
+      "name": "get_weather",
+      "description": "현재 날씨 조회",
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "location": {"type": "string", "description": "도시 이름"}
+        },
+        "required": ["location"]
+      }
+    }
+  }],
+  "tool_choice": "auto"
+}
+```
+
+**응답:**
+```json
+{
+  "id": "chatcmpl-xxxx",
+  "object": "chat.completion",
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "choices": [{
+    "index": 0,
+    "message": {"role": "assistant", "content": "..."},
+    "finish_reason": "stop"
+  }],
+  "usage": {"prompt_tokens": 10, "completion_tokens": 50, "total_tokens": 60}
+}
+```
+
+**파라미터:**
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---------|------|--------|------|
+| `model` | string | 필수 | 모델 ID |
+| `messages` | array | 필수 | 대화 내역 |
+| `max_tokens` | int | 32768 | 최대 출력 토큰 |
+| `temperature` | float | 0.7 | 창의성 (0.0~2.0) |
+| `top_p` | float | 1.0 | nucleus sampling |
+| `stream` | bool | false | 스트리밍 응답 |
+| `tools` | array | - | 도구 정의 목록 |
+| `tool_choice` | string | "auto" | 도구 선택 방식 |
+
+---
+
+## 채팅 (Anthropic)
+
+### `POST /v1/messages`
+
+Anthropic Messages API 호환. Claude Code, Claude SDK와 직접 연결 가능.
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "messages": [{"role": "user", "content": "안녕하세요!"}],
+  "max_tokens": 500
+}
+```
+
+**헤더:**
+```
+x-api-key: dummy
+anthropic-version: 2023-06-01
+```
+
+**응답:**
+```json
+{
+  "id": "msg_xxxx",
+  "type": "message",
+  "role": "assistant",
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "content": [{"type": "text", "text": "..."}],
+  "stop_reason": "end_turn",
+  "usage": {"input_tokens": 10, "output_tokens": 50}
+}
+```
+
+### `POST /v1/messages/count_tokens`
+
+입력 토큰 수 계산.
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "messages": [{"role": "user", "content": "안녕하세요!"}]
+}
+```
+
+---
+
+## 텍스트 완성
+
+### `POST /v1/completions`
+
+OpenAI Completions API 호환 (레거시).
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "prompt": "한국의 수도는",
+  "max_tokens": 50
+}
+```
+
+---
+
+## STT (음성 인식)
+
+### `POST /v1/audio/transcriptions`
+
+OpenAI Whisper API 호환. `multipart/form-data` 전송.
+
+**요청:**
+```bash
+curl http://localhost:8000/v1/audio/transcriptions \
+  -F "file=@audio.wav" \
+  -F "model=whisper-1" \
+  -F "language=ko"
+```
+
+**파라미터:**
+
+| 파라미터 | 타입 | 필수 | 설명 |
+|---------|------|:----:|------|
+| `file` | file | ✅ | 오디오 파일 (wav, mp3, m4a 등) |
+| `model` | string | ✅ | `whisper-1` 고정 |
+| `language` | string | - | 언어 코드 (`ko`, `en` 등). 생략 시 자동 감지 |
+
+**응답:**
+```json
+{"text": "안녕하세요.", "language": "ko", "duration": null}
+```
+
+**내부 모델:** `mlx-community/whisper-large-v3-mlx`
+
+---
+
+## TTS (음성 합성)
+
+### `POST /v1/audio/speech`
+
+OpenAI TTS API 호환. JSON body 전송.
+
+**요청:**
+```json
+{
+  "model": "chatterbox-multilingual",
+  "input": "안녕하세요.",
+  "voice": "wc",
+  "response_format": "wav",
+  "lang_code": "ko"
+}
+```
+
+**응답:** 바이너리 오디오 파일 (`audio/wav`)
+
+**파라미터:**
+
+| 파라미터 | 타입 | 기본값 | 설명 |
+|---------|------|--------|------|
+| `model` | string | `kokoro` | TTS 모델 별칭 |
+| `input` | string | 필수 | 합성할 텍스트 |
+| `voice` | string | `af_heart` | 음성 ID (모델별 상이) |
+| `speed` | float | `1.0` | 속도 (0.5~2.0) |
+| `response_format` | string | `wav` | `wav` 또는 `mp3` |
+| `lang_code` | string | `a` | 언어 코드 |
+| `volume` | float | `0.9` | 출력 음량 (0.0~1.0). RMS 정규화 후 적용 |
+
+**지원 모델:**
+
+| `model` 값 | 실제 모델 | 특징 |
+|-----------|----------|------|
+| `kokoro` | `mlx-community/Kokoro-82M-bf16` | 영어 특화, 빠름 |
+| `kokoro-4bit` | `mlx-community/Kokoro-82M-4bit` | 영어, 경량 |
+| `chatterbox` | `mlx-community/chatterbox-turbo-fp16` | 영어, 고품질 |
+| `chatterbox-multilingual` | `litmudoc/Chatterbox-Multilingual-MLX-v2-fp16` | **다국어(한국어 포함), Voice Cloning** |
+| `vibevoice` | `mlx-community/VibeVoice-Realtime-0.5B-4bit` | 실시간 |
+| `voxcpm` | `mlx-community/VoxCPM1.5` | 중국어/영어 |
+
+**lang_code 값 (`chatterbox-multilingual`):**
+
+| 코드 | 언어 |
+|------|------|
+| `a` | 영어 (American) |
+| `ko` | 한국어 |
+| `ja` | 일본어 |
+| `zh` | 중국어 |
+| `es` | 스페인어 |
+| `fr` | 프랑스어 |
+
+**Kokoro voice 목록:**
+
+| voice | 성별 | 억양 |
+|-------|:----:|------|
+| `af_heart` | 여 | American |
+| `af_bella` | 여 | American |
+| `af_nicole` | 여 | American |
+| `af_sarah` | 여 | American |
+| `af_sky` | 여 | American |
+| `am_adam` | 남 | American |
+| `am_michael` | 남 | American |
+| `bf_emma` | 여 | British |
+| `bf_isabella` | 여 | British |
+| `bm_george` | 남 | British |
+| `bm_lewis` | 남 | British |
+
+**Chatterbox-Multilingual 저장 목소리 (Voice Cloning):**
+
+| `voice` 값 | 설명 |
+|-----------|------|
+| `wc` | 사용자 본인 목소리 |
+| `iu` | IU 목소리 |
+| `default` | 모델 기본 목소리 |
+
+> 새 목소리 추가 방법은 README 참고.
+
+### `GET /v1/audio/voices`
+
+사용 가능한 TTS voice 목록.
+
+**응답:**
+```json
+{"voices": ["af_heart", "af_bella", ...]}
+```
+
+---
+
+## MCP
+
+vllm-mlx 내장 MCP(Model Context Protocol) 연동.
+
+### `GET /v1/mcp/tools`
+
+연결된 MCP 서버의 도구 목록.
+
+**응답:**
+```json
+{
+  "tools": [
+    {"name": "tool_name", "description": "...", "server": "server_name"}
+  ]
+}
+```
+
+### `GET /v1/mcp/servers`
+
+연결된 MCP 서버 목록.
+
+### `POST /v1/mcp/execute`
+
+MCP 도구 직접 실행.
+
+**요청:**
+```json
+{
+  "server": "server_name",
+  "tool": "tool_name",
+  "arguments": {"key": "value"}
+}
+```
+
+---
+
+## 임베딩
+
+### `POST /v1/embeddings`
+
+텍스트 임베딩 벡터 생성.
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "input": "임베딩할 텍스트"
+}
+```
+
+**응답:**
+```json
+{
+  "object": "list",
+  "data": [{"object": "embedding", "index": 0, "embedding": [...]}],
+  "usage": {"prompt_tokens": 5, "total_tokens": 5}
+}
+```
+
+---
+
+## 재순위
+
+### `POST /v1/rerank`
+
+문서 재순위 (Reranking).
+
+**요청:**
+```json
+{
+  "model": "mlx-community/gemma-4-26b-a4b-it-4bit",
+  "query": "검색 쿼리",
+  "documents": ["문서1", "문서2", "문서3"]
+}
+```
+
+---
+
+## 캐시
+
+### `GET /v1/cache/stats`
+캐시 통계 조회.
+
+### `DELETE /v1/cache`
+전체 캐시 삭제.
+
+### `DELETE /v1/cache/prefix`
+prefix 캐시 삭제.
+
+---
+
+## SDK 연동 예시
+
+### Python (OpenAI SDK)
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://localhost:8000/v1", api_key="dummy")
+
+# 채팅
+response = client.chat.completions.create(
+    model="mlx-community/gemma-4-26b-a4b-it-4bit",
+    messages=[{"role": "user", "content": "안녕하세요!"}]
+)
+
+# STT
+with open("audio.wav", "rb") as f:
+    result = client.audio.transcriptions.create(file=f, model="whisper-1", language="ko")
+
+# TTS (Kokoro)
+response = client.audio.speech.create(
+    model="kokoro", input="Hello!", voice="af_heart"
+)
+response.stream_to_file("output.wav")
+```
+
+### Python (Anthropic SDK)
+
+```python
+import anthropic
+
+client = anthropic.Anthropic(
+    base_url="http://localhost:8000",
+    api_key="dummy"
+)
+
+response = client.messages.create(
+    model="mlx-community/gemma-4-26b-a4b-it-4bit",
+    max_tokens=500,
+    messages=[{"role": "user", "content": "안녕하세요!"}]
+)
+```
+
+### Claude Code 연동
+
+```bash
+ANTHROPIC_BASE_URL=http://localhost:8000 \
+ANTHROPIC_API_KEY=dummy \
+claude --model mlx-community/gemma-4-26b-a4b-it-4bit
+```
+
+### curl — 한국어 TTS (Voice Cloning)
+
+```bash
+# 본인 목소리
+curl http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"chatterbox-multilingual","input":"안녕하세요.","voice":"wc","lang_code":"ko","response_format":"wav"}' \
+  -o output.wav
+
+# IU 목소리
+curl http://localhost:8000/v1/audio/speech \
+  -H "Content-Type: application/json" \
+  -d '{"model":"chatterbox-multilingual","input":"안녕하세요.","voice":"iu","lang_code":"ko","response_format":"wav"}' \
+  -o output.wav
+```

--- a/docs/VLLM_API_summary.md
+++ b/docs/VLLM_API_summary.md
@@ -1,0 +1,24 @@
+# vllm-mlx API 엔드포인트 요약
+vllm-mlx 서버에서 제공하는 모든 API 엔드포인트를 카테고리별로 정리한 목록입니다.
+
+| 카테고리 | 메서드 | 엔드포인트 | 역할 (한 줄 요약) |
+| :--- | :--- | :--- | :--- |
+| **시스템** | GET | `/health` | 서버 상태 확인 |
+| **시스템** | GET | `/metrics` | Prometheus 형식 메트릭 조회 |
+| **시스템** | GET | `/v1/status` | 모델 로드 상태 및 설정 정보 확인 |
+| **모델** | GET | `/v1/models` | 로드된 모델 목록 조회 |
+| **채팅 (OpenAI)** | POST | `/v1/chat/completions` | OpenAI 호환 채팅 응답 생성 |
+| **채팅 (Anthropic)** | POST | `/v1/messages` | Anthropic 호환 메시지 생성 |
+| **채팅 (Anthropic)** | POST | `/v1/messages/count_tokens` | 입력 토큰 수 계산 |
+| **텍스트 완성** | POST | `/v1/completions` | 레거시 텍스트 완성 (OpenAI 호환) |
+| **STT (음성 인식)** | POST | `/v1/audio/transcriptions` | 음성 파일을 텍스트로 변환 |
+| **TTS (음성 합성)** | POST | `/v1/audio/speech` | 텍스트를 음성으로 변환 |
+| **TTS (음성 합성)** | GET | `/v1/audio/voices` | 사용 가능한 TTS 목소리 목록 조회 |
+| **MCP** | GET | `/v1/mcp/tools` | 연결된 MCP 서버의 도구 목록 조회 |
+| **MCP** | GET | `/v1/mcp/servers` | 연결된 MCP 서버 목록 조회 |
+| **MCP** | POST | `/v1/mcp/execute` | MCP 도구 직접 실행 |
+| **임베딩** | POST | `/v1/embeddings` | 텍스트 임베딩 벡터 생성 |
+| **재순위** | POST | `/v1/rerank` | 문서 재순위화 (Reranking) |
+| **캐시** | GET | `/v1/cache/stats` | 캐시 통계 조회 |
+| **캐시** | DELETE | `/v1/cache` | 전체 캐시 삭제 |
+| **캐시** | DELETE | `/v1/cache/prefix` | Prefix 캐시 삭제 |

--- a/docs/superpowers/plans/2026-05-03-file-io.md
+++ b/docs/superpowers/plans/2026-05-03-file-io.md
@@ -1,0 +1,766 @@
+# call_local_llm File I/O Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `input_files`, `output_file`, and `append` parameters to `call_local_llm` so the MCP server handles file I/O directly, keeping file contents out of Claude's context window.
+
+**Architecture:** Four standalone functions added to `internal/llm/client.go`: `validatePath` (path security), `buildPromptWithFiles` (file reading), and `writeOutput` (file writing). Three new optional fields added to `Input` struct. `Client` gains `MaxInputBytes` and `WorkDir` fields. `Call()` validates all paths via `validatePath` before passing to helpers. `main.go` parses `LOCAL_LLM_MAX_INPUT_BYTES` and `LOCAL_LLM_WORK_DIR`; `WorkDir` defaults to the binary's directory (same as `usage.json`).
+
+**Tech Stack:** Go, `os` / `path/filepath` standard library, existing `strings.Builder` pattern
+
+---
+
+### Task 0: validatePath (TDD)
+
+**Files:**
+- Modify: `internal/llm/client.go` — add `validatePath` function after `buildImageContent`
+- Modify: `internal/llm/client_test.go` — add `path/filepath` import, add 5 tests
+
+- [ ] **Step 1: Update imports in client_test.go**
+
+In `internal/llm/client_test.go`, replace the import block:
+
+```go
+import (
+	"encoding/base64"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+```
+
+- [ ] **Step 2: Add 5 failing tests for validatePath**
+
+In `internal/llm/client_test.go`, append after `TestBuildImageContent_FileNotFound`:
+
+```go
+func TestValidatePath_RelativeResolved(t *testing.T) {
+	dir := t.TempDir()
+	result, err := validatePath("output.txt", dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := filepath.Join(dir, "output.txt")
+	if result != expected {
+		t.Errorf("expected %q, got %q", expected, result)
+	}
+}
+
+func TestValidatePath_AbsWithinDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir", "file.txt")
+	result, err := validatePath(path, dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != path {
+		t.Errorf("expected %q, got %q", path, result)
+	}
+}
+
+func TestValidatePath_AbsOutsideDir(t *testing.T) {
+	dir := t.TempDir()
+	_, err := validatePath("/etc/passwd", dir)
+	if err == nil {
+		t.Fatal("expected error for path outside work dir")
+	}
+	if !strings.Contains(err.Error(), "outside") {
+		t.Errorf("expected error to mention 'outside', got: %v", err)
+	}
+}
+
+func TestValidatePath_DotDotEscape(t *testing.T) {
+	dir := t.TempDir()
+	_, err := validatePath("../escape.txt", dir)
+	if err == nil {
+		t.Fatal("expected error for dot-dot escape")
+	}
+	if !strings.Contains(err.Error(), "outside") {
+		t.Errorf("expected error to mention 'outside', got: %v", err)
+	}
+}
+
+func TestValidatePath_DotDotAbsolute(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "..", "escape.txt")
+	_, err := validatePath(path, dir)
+	if err == nil {
+		t.Fatal("expected error for absolute path that escapes via ../")
+	}
+	if !strings.Contains(err.Error(), "outside") {
+		t.Errorf("expected error to mention 'outside', got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 3: Run tests — verify they fail**
+
+```bash
+go test ./internal/llm/ -run TestValidatePath -v
+```
+
+Expected: compilation error `undefined: validatePath`
+
+- [ ] **Step 4: Implement validatePath**
+
+In `internal/llm/client.go`, add this function after `buildImageContent` (after line ~151). Also add `"path/filepath"` to the import block.
+
+Updated import block:
+
+```go
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+```
+
+New function:
+
+```go
+func validatePath(path, workDir string) (string, error) {
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(workDir, path)
+	}
+	path = filepath.Clean(path)
+	workDir = filepath.Clean(workDir)
+	if path != workDir && !strings.HasPrefix(path, workDir+string(filepath.Separator)) {
+		return "", fmt.Errorf("path %q is outside work directory %q", path, workDir)
+	}
+	return path, nil
+}
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+```bash
+go test ./internal/llm/ -run TestValidatePath -v
+```
+
+Expected: all 5 tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: add validatePath with TDD"
+```
+
+---
+
+### Task 1: buildPromptWithFiles (TDD)
+
+**Files:**
+- Modify: `internal/llm/client.go` — add `buildPromptWithFiles` function after `validatePath`
+- Modify: `internal/llm/client_test.go` — add 5 tests
+
+- [ ] **Step 1: Add 5 failing tests for buildPromptWithFiles**
+
+In `internal/llm/client_test.go`, append after `TestValidatePath_DotDotAbsolute`:
+
+```go
+func TestBuildPromptWithFiles_Single(t *testing.T) {
+	f, err := os.CreateTemp("", "llm-test-*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	content := "package main\n\nfunc main() {}"
+	if _, err := f.WriteString(content); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	result, err := buildPromptWithFiles("summarize this", []string{f.Name()}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	expected := "summarize this\n\n[file: " + f.Name() + "]\n" + content + "\n"
+	if result != expected {
+		t.Errorf("expected:\n%q\ngot:\n%q", expected, result)
+	}
+}
+
+func TestBuildPromptWithFiles_Multiple(t *testing.T) {
+	f1, err := os.CreateTemp("", "llm-test-a-*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f1.Name())
+	f2, err := os.CreateTemp("", "llm-test-b-*.md")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f2.Name())
+	if _, err := f1.WriteString("content A"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f2.WriteString("content B"); err != nil {
+		t.Fatal(err)
+	}
+	f1.Close()
+	f2.Close()
+
+	result, err := buildPromptWithFiles("my prompt", []string{f1.Name(), f2.Name()}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(result, "[file: "+f1.Name()+"]") {
+		t.Errorf("missing header for file1 in: %s", result)
+	}
+	if !strings.Contains(result, "[file: "+f2.Name()+"]") {
+		t.Errorf("missing header for file2 in: %s", result)
+	}
+	if strings.Index(result, f1.Name()) > strings.Index(result, f2.Name()) {
+		t.Errorf("file1 should appear before file2")
+	}
+}
+
+func TestBuildPromptWithFiles_FileNotFound(t *testing.T) {
+	_, err := buildPromptWithFiles("prompt", []string{"/nonexistent/path/missing.go"}, 0)
+	if err == nil {
+		t.Fatal("expected error for missing file")
+	}
+	if !strings.Contains(err.Error(), "input_files[0]") {
+		t.Errorf("expected error to mention input_files[0], got: %v", err)
+	}
+}
+
+func TestBuildPromptWithFiles_SizeExceeds(t *testing.T) {
+	f, err := os.CreateTemp("", "llm-test-large-*.txt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.WriteString(strings.Repeat("x", 100)); err != nil {
+		t.Fatal(err)
+	}
+	f.Close()
+
+	_, err = buildPromptWithFiles("prompt", []string{f.Name()}, 50)
+	if err == nil {
+		t.Fatal("expected error when total size exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected error to mention 'exceeds limit', got: %v", err)
+	}
+}
+
+func TestBuildPromptWithFiles_Empty(t *testing.T) {
+	result, err := buildPromptWithFiles("my prompt", []string{}, 0)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "my prompt" {
+		t.Errorf("expected prompt unchanged, got: %q", result)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+go test ./internal/llm/ -run TestBuildPromptWithFiles -v
+```
+
+Expected: compilation error `undefined: buildPromptWithFiles`
+
+- [ ] **Step 3: Implement buildPromptWithFiles**
+
+In `internal/llm/client.go`, add this function after `validatePath`:
+
+```go
+func buildPromptWithFiles(prompt string, files []string, maxBytes int) (string, error) {
+	if len(files) == 0 {
+		return prompt, nil
+	}
+	type fileData struct {
+		path    string
+		content []byte
+	}
+	var total int
+	loaded := make([]fileData, 0, len(files))
+	for i, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("input_files[%d]: file not found: %s", i, path)
+			}
+			if os.IsPermission(err) {
+				return "", fmt.Errorf("input_files[%d]: permission denied: %s", i, path)
+			}
+			return "", fmt.Errorf("input_files[%d]: read failed: %w", i, err)
+		}
+		total += len(data)
+		if maxBytes > 0 && total > maxBytes {
+			return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
+				"Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
+		}
+		loaded = append(loaded, fileData{path: path, content: data})
+	}
+	var sb strings.Builder
+	sb.WriteString(prompt)
+	for _, f := range loaded {
+		sb.WriteString("\n\n[file: ")
+		sb.WriteString(f.path)
+		sb.WriteString("]\n")
+		sb.Write(f.content)
+	}
+	result := sb.String()
+	if len(result) > 0 && result[len(result)-1] != '\n' {
+		result += "\n"
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+go test ./internal/llm/ -run TestBuildPromptWithFiles -v
+```
+
+Expected: all 5 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: add buildPromptWithFiles with TDD"
+```
+
+---
+
+### Task 2: writeOutput (TDD)
+
+**Files:**
+- Modify: `internal/llm/client.go` — add `writeOutput` function after `buildPromptWithFiles`
+- Modify: `internal/llm/client_test.go` — add 4 tests
+
+- [ ] **Step 1: Add 4 failing tests for writeOutput**
+
+In `internal/llm/client_test.go`, append after `TestBuildPromptWithFiles_Empty`:
+
+```go
+func TestWriteOutput_NewFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+
+	summary, err := writeOutput(path, "hello world", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("file not created: %v", err)
+	}
+	if string(got) != "hello world" {
+		t.Errorf("expected %q, got %q", "hello world", string(got))
+	}
+	if !strings.Contains(summary, "saved 11 bytes") {
+		t.Errorf("expected summary to contain 'saved 11 bytes', got: %s", summary)
+	}
+}
+
+func TestWriteOutput_Overwrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	if err := os.WriteFile(path, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := writeOutput(path, "new content", false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "new content" {
+		t.Errorf("expected overwrite, got %q", string(got))
+	}
+}
+
+func TestWriteOutput_Append(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "output.txt")
+	if err := os.WriteFile(path, []byte("first\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := writeOutput(path, "second\n", true)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != "first\nsecond\n" {
+		t.Errorf("expected appended content, got %q", string(got))
+	}
+}
+
+func TestWriteOutput_DirNotFound(t *testing.T) {
+	_, err := writeOutput("/nonexistent/dir/output.txt", "content", false)
+	if err == nil {
+		t.Fatal("expected error when parent directory missing")
+	}
+	if !strings.Contains(err.Error(), "output_file") {
+		t.Errorf("expected error to contain 'output_file', got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+go test ./internal/llm/ -run TestWriteOutput -v
+```
+
+Expected: compilation error `undefined: writeOutput`
+
+- [ ] **Step 3: Implement writeOutput**
+
+In `internal/llm/client.go`, add this function immediately after `buildPromptWithFiles`:
+
+```go
+func writeOutput(path, text string, appendMode bool) (string, error) {
+	if appendMode {
+		f, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0644)
+		if err != nil {
+			return "", fmt.Errorf("output_file: %w", err)
+		}
+		defer f.Close()
+		if _, err := f.WriteString(text); err != nil {
+			return "", fmt.Errorf("output_file: write failed: %w", err)
+		}
+	} else {
+		if err := os.WriteFile(path, []byte(text), 0644); err != nil {
+			return "", fmt.Errorf("output_file: %w", err)
+		}
+	}
+	return fmt.Sprintf("saved %d bytes to %s", len(text), path), nil
+}
+```
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+go test ./internal/llm/ -run TestWriteOutput -v
+```
+
+Expected: all 4 tests PASS
+
+- [ ] **Step 5: Run all tests**
+
+```bash
+go test ./internal/llm/ -v
+```
+
+Expected: all 24 tests PASS (10 image + 5 validatePath + 5 buildPromptWithFiles + 4 writeOutput)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: add writeOutput with TDD"
+```
+
+---
+
+### Task 3: Wire into Input, Client, Call, and main.go
+
+**Files:**
+- Modify: `internal/llm/client.go` — extend `Input`, `Client`, `NewClient`, `Call`
+- Modify: `cmd/mcp-local-llm/main.go` — parse `LOCAL_LLM_MAX_INPUT_BYTES` and `LOCAL_LLM_WORK_DIR`, pass to `NewClient`
+
+- [ ] **Step 1: Add fields to Input struct**
+
+In `internal/llm/client.go`, replace the `Input` struct (lines 31–38):
+
+```go
+type Input struct {
+	Prompt         string   `json:"prompt"                    jsonschema:"LLM에 전달할 사용자 메시지,required"`
+	System         string   `json:"system,omitempty"          jsonschema:"시스템 프롬프트 (선택사항)"`
+	Model          string   `json:"model,omitempty"           jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
+	MaxTokens      int      `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (생략 시 서버 기본값 사용)"`
+	FilterThinking *bool    `json:"filter_thinking,omitempty" jsonschema:"thinking 블록 필터링 여부 (true=필터, false=유지). 생략 시 서버 기본값(LOCAL_LLM_FILTER_THINKING) 적용"`
+	Images         []string `json:"images,omitempty"          jsonschema:"이미지 목록 (파일 경로·URL·base64 data URI 혼합 가능)"`
+	InputFiles     []string `json:"input_files,omitempty"     jsonschema:"읽어서 프롬프트에 포함할 파일 경로 목록. MCP 서버가 직접 읽어 Claude 컨텍스트 절약"`
+	OutputFile     string   `json:"output_file,omitempty"     jsonschema:"결과를 저장할 파일 경로. 지정 시 저장 완료 메시지만 반환 (Claude 컨텍스트 절약)"`
+	Append         bool     `json:"append,omitempty"          jsonschema:"true이면 output_file에 이어쓰기. 기본값 false (덮어쓰기)"`
+}
+```
+
+- [ ] **Step 2: Add WorkDir and MaxInputBytes to Client struct**
+
+In `internal/llm/client.go`, replace the `Client` struct (lines 69–77):
+
+```go
+type Client struct {
+	BaseURL          string
+	DefaultModel     string
+	DefaultMaxTokens int
+	FilterThinking   bool
+	MaxImages        int
+	MaxInputBytes    int
+	WorkDir          string
+	httpClient       *http.Client
+	sem              chan struct{}
+}
+```
+
+- [ ] **Step 3: Update NewClient signature and body**
+
+In `internal/llm/client.go`, replace the `NewClient` function (lines 79–96):
+
+```go
+func NewClient(baseURL, model string, maxTokens int, timeout time.Duration, maxConcurrent int, filterThinking bool, maxImages int, maxInputBytes int, workDir string) *Client {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+	var sem chan struct{}
+	if maxConcurrent > 0 {
+		sem = make(chan struct{}, maxConcurrent)
+	}
+	return &Client{
+		BaseURL:          baseURL,
+		DefaultModel:     model,
+		DefaultMaxTokens: maxTokens,
+		FilterThinking:   filterThinking,
+		MaxImages:        maxImages,
+		MaxInputBytes:    maxInputBytes,
+		WorkDir:          workDir,
+		httpClient:       &http.Client{Timeout: timeout},
+		sem:              sem,
+	}
+}
+```
+
+- [ ] **Step 4: Update Call() to validate paths and use buildPromptWithFiles / writeOutput**
+
+In `internal/llm/client.go`, replace the entire `Call` function (lines 153–234):
+
+```go
+func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
+	if c.sem != nil {
+		select {
+		case c.sem <- struct{}{}:
+			defer func() { <-c.sem }()
+		case <-ctx.Done():
+			return "", Usage{}, ctx.Err()
+		}
+	}
+
+	// Validate and resolve input file paths against work directory
+	inputFiles := make([]string, len(in.InputFiles))
+	for i, f := range in.InputFiles {
+		p, err := validatePath(f, c.WorkDir)
+		if err != nil {
+			return "", Usage{}, fmt.Errorf("input_files[%d]: %w", i, err)
+		}
+		inputFiles[i] = p
+	}
+
+	// Validate and resolve output file path against work directory
+	outputFile := in.OutputFile
+	if in.OutputFile != "" {
+		p, err := validatePath(in.OutputFile, c.WorkDir)
+		if err != nil {
+			return "", Usage{}, fmt.Errorf("output_file: %w", err)
+		}
+		outputFile = p
+	}
+
+	prompt := in.Prompt
+	if len(inputFiles) > 0 {
+		var err error
+		prompt, err = buildPromptWithFiles(in.Prompt, inputFiles, c.MaxInputBytes)
+		if err != nil {
+			return "", Usage{}, err
+		}
+	}
+
+	messages := []chatMessage{}
+	if in.System != "" {
+		messages = append(messages, chatMessage{Role: "system", Content: in.System})
+	}
+	if len(in.Images) > 0 {
+		parts, err := buildImageContent(prompt, in.Images, c.MaxImages)
+		if err != nil {
+			return "", Usage{}, err
+		}
+		messages = append(messages, chatMessage{Role: "user", Content: parts})
+	} else {
+		messages = append(messages, chatMessage{Role: "user", Content: prompt})
+	}
+
+	model := in.Model
+	if model == "" {
+		model = c.DefaultModel
+	}
+	var maxTokens *int
+	if in.MaxTokens > 0 {
+		v := in.MaxTokens
+		maxTokens = &v
+	} else if c.DefaultMaxTokens > 0 {
+		v := c.DefaultMaxTokens
+		maxTokens = &v
+	}
+
+	body, err := json.Marshal(chatRequest{Model: model, Messages: messages, MaxTokens: maxTokens})
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("marshal failed: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("create request failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("read response failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", Usage{}, fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
+	}
+
+	var result chatResponse
+	if err := json.Unmarshal(raw, &result); err != nil {
+		return "", Usage{}, fmt.Errorf("parse failed: %w", err)
+	}
+	if result.Error != nil {
+		return "", Usage{}, fmt.Errorf("API error: %s", result.Error.Message)
+	}
+	if len(result.Choices) == 0 {
+		return "", Usage{}, fmt.Errorf("empty response")
+	}
+	content := result.Choices[0].Message.Content
+	filterThinking := c.FilterThinking
+	if in.FilterThinking != nil {
+		filterThinking = *in.FilterThinking
+	}
+	if filterThinking {
+		content = strings.TrimSpace(thinkingRe.ReplaceAllString(content, ""))
+	}
+
+	if outputFile != "" {
+		summary, err := writeOutput(outputFile, content, in.Append)
+		if err != nil {
+			return "", Usage{}, err
+		}
+		return summary, result.Usage, nil
+	}
+
+	return content, result.Usage, nil
+}
+```
+
+- [ ] **Step 5: Parse LOCAL_LLM_MAX_INPUT_BYTES and LOCAL_LLM_WORK_DIR in main.go**
+
+In `cmd/mcp-local-llm/main.go`, replace the `client := llm.NewClient(...)` line (line 133):
+
+```go
+	maxInputBytes := 98304
+	if v := os.Getenv("LOCAL_LLM_MAX_INPUT_BYTES"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			maxInputBytes = n
+		}
+	}
+
+	workDir := filepath.Dir(usagePath)
+	if v := os.Getenv("LOCAL_LLM_WORK_DIR"); v != "" {
+		workDir = v
+	}
+
+	client := llm.NewClient(baseURL, model, maxTokens, timeout, maxConcurrent, filterThinking, maxImages, maxInputBytes, workDir)
+```
+
+Note: `usagePath` is already computed on the line above (`stats := loadUsage(usagePath)`), and `filepath.Dir(usagePath)` gives the binary's directory. `"path/filepath"` is already imported in `main.go`.
+
+- [ ] **Step 6: Build**
+
+```bash
+make build
+```
+
+Expected: no errors, `bin/mcp-local-llm` updated
+
+- [ ] **Step 7: Run all tests**
+
+```bash
+go test ./... -v
+```
+
+Expected: all 24 tests PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add internal/llm/client.go cmd/mcp-local-llm/main.go
+git commit -m "feat: wire input_files, output_file, and path validation into call_local_llm"
+```
+
+---
+
+### Task 4: Update docs
+
+**Files:**
+- Modify: `README.md` — add 3 parameter rows, add 2 env var rows to Configuration table
+- Modify: `.env.example` — add `LOCAL_LLM_MAX_IMAGES`, `LOCAL_LLM_MAX_INPUT_BYTES`, `LOCAL_LLM_WORK_DIR`
+
+- [ ] **Step 1: Add 3 parameter rows to the call_local_llm table in README.md**
+
+In `README.md`, in the `call_local_llm` parameters table, add after the `| images | ...` row:
+
+```markdown
+| `input_files` | no | List of file paths for the MCP server to read and include in the prompt. File contents are appended after `prompt`, keeping them out of Claude's context window. All paths must be within `LOCAL_LLM_WORK_DIR`. Combined size is limited by `LOCAL_LLM_MAX_INPUT_BYTES`. |
+| `output_file` | no | File path to write the LLM response to. When set, returns `"saved N bytes to path"` instead of the full response, keeping large outputs out of Claude's context window. Must be within `LOCAL_LLM_WORK_DIR`. Parent directory must exist. |
+| `append` | no | When `true`, appends to an existing `output_file` instead of overwriting. Ignored when `output_file` is not set. Default: `false`. |
+```
+
+- [ ] **Step 2: Add 2 env var rows to the Configuration table in README.md**
+
+In `README.md`, in the Configuration table, add after the `| LOCAL_LLM_MAX_IMAGES | ...` row:
+
+```markdown
+| `LOCAL_LLM_MAX_INPUT_BYTES` | `98304` | Maximum combined size of all `input_files` in bytes (96 KB ≈ 24,000 tokens). Set to `0` for no limit (not recommended — server may crash on large inputs). |
+| `LOCAL_LLM_WORK_DIR` | binary directory | Base directory for all `input_files` and `output_file` paths. All paths must resolve within this directory; relative paths are resolved against it. Prevents access outside the designated workspace. |
+```
+
+- [ ] **Step 3: Update .env.example**
+
+In `.env.example`, replace the file contents with:
+
+```
+LOCAL_LLM_BASE_URL=http://localhost:8000
+LOCAL_LLM_MODEL=mlx-community/gemma-4-26b-a4b-it-4bit
+LOCAL_LLM_MAX_TOKENS=32768
+LOCAL_LLM_TIMEOUT_SECONDS=300
+LOCAL_LLM_MAX_CONCURRENT=2
+LOCAL_LLM_MAX_IMAGES=5
+LOCAL_LLM_MAX_INPUT_BYTES=98304
+LOCAL_LLM_WORK_DIR=/path/to/work/dir
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md .env.example
+git commit -m "docs: add input_files, output_file, append, and path security to call_local_llm reference"
+```

--- a/docs/superpowers/plans/2026-05-04-retry-transient-errors.md
+++ b/docs/superpowers/plans/2026-05-04-retry-transient-errors.md
@@ -1,0 +1,486 @@
+# Retry on Transient Errors — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add automatic retry (max 2 attempts, 200ms/1s backoff) for 5xx and transient network errors in `Call()`.
+
+**Architecture:** Extract `isRetryable(err, statusCode)` helper, then wrap only the HTTP dispatch section of `Call()` in a retry loop. All upstream logic (semaphore, validation, prompt building) stays outside the loop. Request body is re-created each attempt from the already-marshaled `body` byte slice.
+
+**Tech Stack:** Go standard library — `net`, `errors`, `time`
+
+---
+
+### Task 1: GitHub issue + feature branch
+
+**Files:**
+- No code files
+
+- [ ] **Step 1: Create GitHub issue**
+
+```bash
+gh issue create \
+  --title "feat: retry on transient errors in Call()" \
+  --body "$(cat <<'EOF'
+## Motivation
+
+`Call()` returns immediately on 5xx or temporary network errors (connection refused, temporary net.Error). When vllm-mlx is momentarily unstable, the MCP caller sees a hard failure with no retry opportunity.
+
+## Implementation
+
+- Add `isRetryable(err error, statusCode int) bool` helper
+- Wrap HTTP dispatch in `Call()` with a retry loop: max 2 retries, delays [200ms, 1s]
+- Retry on: HTTP 5xx, `net.Error.Temporary()==true`, `"connection refused"` in error string
+- Non-retryable: 4xx, context cancellation, other errors
+- No new env vars — constants only
+EOF
+)"
+```
+
+Note the issue number printed (e.g. `#21`).
+
+- [ ] **Step 2: Create feature branch**
+
+Replace `{N}` with the actual issue number:
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feat/issue-{N}-retry-transient-errors
+```
+
+---
+
+### Task 2: `isRetryable` — failing tests first
+
+**Files:**
+- Modify: `internal/llm/client_test.go`
+
+- [ ] **Step 1: Add failing tests for `isRetryable`**
+
+Append to `internal/llm/client_test.go`:
+
+```go
+func TestIsRetryable_5xx(t *testing.T) {
+	for _, code := range []int{500, 502, 503, 504} {
+		if !isRetryable(nil, code) {
+			t.Errorf("expected 5xx %d to be retryable", code)
+		}
+	}
+}
+
+func TestIsRetryable_NonRetryableStatus(t *testing.T) {
+	for _, code := range []int{0, 200, 400, 404, 422} {
+		if isRetryable(nil, code) {
+			t.Errorf("expected status %d to be non-retryable", code)
+		}
+	}
+}
+
+func TestIsRetryable_ConnectionRefused(t *testing.T) {
+	err := fmt.Errorf("dial tcp: connection refused")
+	if !isRetryable(err, 0) {
+		t.Error("expected connection refused error to be retryable")
+	}
+}
+
+func TestIsRetryable_NilError_ZeroStatus(t *testing.T) {
+	if isRetryable(nil, 0) {
+		t.Error("nil error with zero status should not be retryable")
+	}
+}
+
+func TestIsRetryable_NonNetworkError(t *testing.T) {
+	err := fmt.Errorf("some other error")
+	if isRetryable(err, 0) {
+		t.Error("generic non-network error should not be retryable")
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — confirm they fail**
+
+```bash
+cd /Volumes/dev-disk/dev-workspace/mcp-local-llm
+go test ./internal/llm/ -run TestIsRetryable -v
+```
+
+Expected: `FAIL` — `isRetryable` undefined.
+
+---
+
+### Task 3: Implement `isRetryable`
+
+**Files:**
+- Modify: `internal/llm/client.go`
+
+- [ ] **Step 1: Add imports `"errors"` and `"net"` to the import block**
+
+Current import block (lines 3–16):
+```go
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+```
+
+Replace with:
+```go
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+```
+
+- [ ] **Step 2: Add constants and `isRetryable` after the `thinkingRe` line (line 18)**
+
+After `var thinkingRe = ...` add:
+
+```go
+const maxRetries = 2
+
+var retryDelays = [maxRetries]time.Duration{
+	200 * time.Millisecond,
+	1 * time.Second,
+}
+
+func isRetryable(err error, statusCode int) bool {
+	if statusCode >= 500 {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Temporary() { //nolint:staticcheck
+		return true
+	}
+	return strings.Contains(err.Error(), "connection refused")
+}
+```
+
+- [ ] **Step 3: Run `isRetryable` tests — confirm they pass**
+
+```bash
+go test ./internal/llm/ -run TestIsRetryable -v
+```
+
+Expected: all `PASS`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: add isRetryable helper with tests"
+```
+
+---
+
+### Task 4: Retry loop in `Call()` — failing tests first
+
+**Files:**
+- Modify: `internal/llm/client_test.go`
+
+- [ ] **Step 1: Add failing integration tests for retry behavior**
+
+Append to `internal/llm/client_test.go`. These require adding `"net/http"`, `"net/http/httptest"`, `"context"`, and `"sync/atomic"` imports — add them to the import block at the top of the test file:
+
+```go
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+)
+```
+
+Then append these test functions:
+
+```go
+func TestCall_RetriesOn503ThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	// Zero out retry delays for fast test
+	retryDelays = [maxRetries]time.Duration{0, 0}
+
+	text, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if text != "ok" {
+		t.Errorf("expected 'ok', got %q", text)
+	}
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestCall_ExhaustsRetries(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	retryDelays = [maxRetries]time.Duration{0, 0}
+
+	_, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error after exhausted retries")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected 503 in error, got: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts (1 + 2 retries), got %d", attempts.Load())
+	}
+}
+
+func TestCall_NoRetryOn4xx(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	retryDelays = [maxRetries]time.Duration{0, 0}
+
+	_, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if attempts.Load() != 1 {
+		t.Errorf("expected exactly 1 attempt for 4xx, got %d", attempts.Load())
+	}
+}
+
+func TestCall_ContextCancelledDuringRetry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	// Use real delays so context cancellation can fire
+	retryDelays = [maxRetries]time.Duration{500 * time.Millisecond, 1 * time.Second}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, _, err := c.Call(ctx, &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	// Either context error or the 503 from the first attempt
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected context or 503 error, got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Restore retryDelays default in test teardown**
+
+Note: The tests mutate the package-level `retryDelays`. Because tests in `package llm` share the same package state, each test that mutates `retryDelays` must restore it. Add a `t.Cleanup` call to each test that changes `retryDelays`:
+
+In `TestCall_RetriesOn503ThenSucceeds`, after setting delays:
+```go
+orig := retryDelays
+retryDelays = [maxRetries]time.Duration{0, 0}
+t.Cleanup(func() { retryDelays = orig })
+```
+
+Apply the same pattern to `TestCall_ExhaustsRetries` and `TestCall_NoRetryOn4xx`. (The context cancellation test uses real delays so no override needed beyond its own restore.)
+
+- [ ] **Step 3: Run new tests — confirm they fail**
+
+```bash
+go test ./internal/llm/ -run TestCall_ -v
+```
+
+Expected: `FAIL` — retry behavior does not exist yet.
+
+---
+
+### Task 5: Implement retry loop in `Call()`
+
+**Files:**
+- Modify: `internal/llm/client.go`
+
+- [ ] **Step 1: Replace the HTTP dispatch block in `Call()`**
+
+Current block to replace (lines 309–328):
+
+```go
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("create request failed: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", Usage{}, fmt.Errorf("read response failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", Usage{}, fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
+	}
+```
+
+Replace with:
+
+```go
+	var (
+		resp    *http.Response
+		raw     []byte
+		doErr   error
+	)
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(retryDelays[attempt-1]):
+			case <-ctx.Done():
+				return "", Usage{}, ctx.Err()
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return "", Usage{}, fmt.Errorf("create request failed: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
+
+		resp, doErr = c.httpClient.Do(req)
+		if doErr != nil {
+			if !isRetryable(doErr, 0) {
+				return "", Usage{}, fmt.Errorf("request failed: %w", doErr)
+			}
+			continue
+		}
+
+		raw, doErr = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if doErr != nil {
+			return "", Usage{}, fmt.Errorf("read response failed: %w", doErr)
+		}
+		doErr = nil
+
+		if !isRetryable(nil, resp.StatusCode) {
+			break
+		}
+	}
+	if doErr != nil {
+		return "", Usage{}, fmt.Errorf("request failed: %w", doErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", Usage{}, fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
+	}
+```
+
+- [ ] **Step 2: Run all tests**
+
+```bash
+go test ./internal/llm/ -v
+```
+
+Expected: all `PASS`.
+
+- [ ] **Step 3: Build to verify compilation**
+
+```bash
+make build
+```
+
+Expected: `bin/mcp-local-llm` created with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: retry on transient errors in Call() — max 2 retries, 200ms/1s backoff"
+```
+
+---
+
+### Task 6: PR
+
+**Files:**
+- No code files
+
+- [ ] **Step 1: Push branch and open PR**
+
+Replace `{N}` with the actual issue number:
+
+```bash
+git push -u origin feat/issue-{N}-retry-transient-errors
+gh pr create \
+  --title "feat: retry on transient errors (issue #{N})" \
+  --body "$(cat <<'EOF'
+## Summary
+
+- Add `isRetryable(err, statusCode)` helper in `internal/llm/client.go`
+- Wrap HTTP dispatch in `Call()` with retry loop: max 2 retries, delays [200ms, 1s]
+- Retry on HTTP 5xx, `net.Error.Temporary()`, and `"connection refused"` errors
+- Non-retryable: 4xx, context cancellation, read errors
+- No new configuration surface (hardcoded constants)
+
+Closes #{N}
+
+## Test plan
+
+- [ ] `TestIsRetryable_*` — unit tests for retry condition helper
+- [ ] `TestCall_RetriesOn503ThenSucceeds` — 2× 503 then 200 → success
+- [ ] `TestCall_ExhaustsRetries` — 3× 503 → error with 503 in message
+- [ ] `TestCall_NoRetryOn4xx` — 400 → exactly 1 attempt
+- [ ] `TestCall_ContextCancelledDuringRetry` — context timeout during backoff sleep
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-02-file-io-design.md
+++ b/docs/superpowers/specs/2026-05-02-file-io-design.md
@@ -73,21 +73,51 @@ Before calling the LLM, validate total input size:
 //  Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit."
 ```
 
+### Path Security
+
+The MCP server runs as the OS user and can read/write any path that user can access. To prevent accidental or malicious path traversal, all `input_files` and `output_file` paths are validated against a **work directory** before use.
+
+**Work directory:** defaults to the directory containing the MCP binary (same directory as `usage.json`). Override with `LOCAL_LLM_WORK_DIR`.
+
+**Validation rules (applied to every path before I/O):**
+1. Relative paths are resolved against the work directory: `"output.txt"` → `"/work/dir/output.txt"`
+2. The resolved path is normalized with `filepath.Clean()` to collapse `../` sequences
+3. The normalized path must be equal to or start with `workDir + "/"` — any path that escapes the work directory is rejected
+
+```
+"output.txt"                → /work/dir/output.txt          ✅
+"subdir/notes.md"           → /work/dir/subdir/notes.md     ✅
+"../escape.txt"             → /escape.txt                   ❌ outside work dir
+"/etc/passwd"               → /etc/passwd                   ❌ outside work dir
+"/work/dir/../etc/passwd"   → /etc/passwd                   ❌ outside work dir (after Clean)
+```
+
+This is implemented in a standalone `validatePath(path, workDir string) (string, error)` function in `internal/llm/client.go`. `Call()` validates all paths before passing them to `buildPromptWithFiles` or `writeOutput`.
+
 ### Error Handling
 
 | Situation | Error Message |
 |-----------|---------------|
+| Path outside work dir (input) | `input_files[N]: path "/etc/passwd" is outside work directory "/work/dir"` |
+| Path outside work dir (output) | `output_file: path "/etc/passwd" is outside work directory "/work/dir"` |
 | File not found | `input_files[N]: file not found: path/to/file` |
 | Permission denied (read) | `input_files[N]: permission denied: path/to/file` |
 | Total size exceeded | `input_files total size (X bytes) exceeds limit (Y bytes)` |
-| Output dir not found | `output_file: directory not found: path/to/dir` |
-| Permission denied (write) | `output_file: permission denied: path/to/file` |
+| Output dir not found | `output_file: open ...: no such file or directory` |
+| Permission denied (write) | `output_file: open ...: permission denied` |
 
 All errors returned as `CallToolResult{IsError: true}` per project convention.
 
 ## Testing
 
-9 unit tests in `internal/llm/client_test.go`:
+14 unit tests in `internal/llm/client_test.go`:
+
+**validatePath (5 tests):**
+- `TestValidatePath_RelativeResolved` — relative path resolved to workDir
+- `TestValidatePath_AbsWithinDir` — absolute path within workDir is allowed
+- `TestValidatePath_AbsOutsideDir` — absolute path outside workDir is rejected
+- `TestValidatePath_DotDotEscape` — `../` relative escape is rejected
+- `TestValidatePath_DotDotAbsolute` — `/../` absolute escape rejected after Clean
 
 **input_files (5 tests):**
 - `TestBuildPromptWithFiles_Single` — single file, header format verified
@@ -107,3 +137,4 @@ All errors returned as `CallToolResult{IsError: true}` per project convention.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `LOCAL_LLM_MAX_INPUT_BYTES` | `98304` | Maximum combined size of all input_files in bytes (96KB ≈ 24,000 tokens). Set to 0 for no limit (not recommended — server may crash). |
+| `LOCAL_LLM_WORK_DIR` | binary directory | Base directory for all `input_files` and `output_file` paths. All paths must resolve within this directory. Relative paths are resolved against it. |

--- a/docs/superpowers/specs/2026-05-04-retry-transient-errors-design.md
+++ b/docs/superpowers/specs/2026-05-04-retry-transient-errors-design.md
@@ -1,0 +1,62 @@
+# Retry on Transient Errors — Design Spec
+
+**Date:** 2026-05-04
+**Scope:** `internal/llm/client.go` — `Call()` only
+
+## Problem
+
+`Call()` returns immediately on any HTTP error or non-200 status. When vllm-mlx is momentarily unstable (5xx, connection refused, temporary network error), the MCP caller sees a failure with no retry opportunity.
+
+## Design
+
+### Constants (hardcoded)
+
+```go
+const (
+    maxRetries  = 2
+    retryDelay0 = 200 * time.Millisecond
+    retryDelay1 = 1 * time.Second
+)
+
+var retryDelays = [maxRetries]time.Duration{retryDelay0, retryDelay1}
+```
+
+### Retry condition
+
+```go
+func isRetryable(err error, statusCode int) bool
+```
+
+Returns true when:
+- `err != nil` and (`net.Error` with `Temporary()==true` OR error string contains `"connection refused"`)
+- `statusCode >= 500`
+
+Non-retryable: 4xx client errors, context cancellation, non-network errors.
+
+### Call() change
+
+Only the HTTP dispatch segment is wrapped in a retry loop (semaphore acquire, path validation, and prompt building remain outside):
+
+```
+for attempt := 0; attempt <= maxRetries; attempt++:
+    if attempt > 0:
+        select { case <-time.After(retryDelays[attempt-1]): case <-ctx.Done(): return ctx.Err() }
+    do HTTP request → parse response
+    if !isRetryable(err, statusCode): break
+return last error
+```
+
+### Error message
+
+On exhausted retries, return the last error as-is (no wrapping with retry count — keeps error messages clean for MCP callers).
+
+## Testing
+
+- `isRetryable()` unit tests: 5xx → true, 4xx → false, `net.Error{Temporary:true}` → true, `context.Canceled` → false
+- `Call()` retry integration: mock server returning 503 twice then 200 → success; mock returning 503 three times → error
+
+## Out of scope
+
+- Configurable retry count / delay (hardcoded constants)
+- Retry on POST idempotency concerns (prompts are non-deterministic by nature; retry is acceptable)
+- README / env var changes (no new configuration surface)

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -5,8 +5,10 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -17,7 +19,29 @@ import (
 
 var thinkingRe = regexp.MustCompile(`(?s)<\|channel>thought.*?<channel\|>`)
 
-const defaultTimeout = 5 * time.Minute
+const (
+	defaultTimeout = 5 * time.Minute
+	maxRetries     = 2
+)
+
+var retryDelays = [maxRetries]time.Duration{
+	200 * time.Millisecond,
+	1 * time.Second,
+}
+
+func isRetryable(err error, statusCode int) bool {
+	if statusCode >= 500 {
+		return true
+	}
+	if err == nil {
+		return false
+	}
+	var netErr net.Error
+	if errors.As(err, &netErr) && netErr.Temporary() { //nolint:staticcheck
+		return true
+	}
+	return strings.Contains(err.Error(), "connection refused")
+}
 
 type contentPart struct {
 	Type     string    `json:"type"`

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -330,23 +330,47 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 		return "", Usage{}, fmt.Errorf("marshal failed: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
-	if err != nil {
-		return "", Usage{}, fmt.Errorf("create request failed: %w", err)
-	}
-	req.Header.Set("Content-Type", "application/json")
+	var (
+		resp  *http.Response
+		raw   []byte
+		doErr error
+	)
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-time.After(retryDelays[attempt-1]):
+			case <-ctx.Done():
+				return "", Usage{}, ctx.Err()
+			}
+		}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.BaseURL+"/v1/chat/completions", bytes.NewReader(body))
+		if err != nil {
+			return "", Usage{}, fmt.Errorf("create request failed: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	resp, err := c.httpClient.Do(req)
-	if err != nil {
-		return "", Usage{}, fmt.Errorf("request failed: %w", err)
-	}
-	defer resp.Body.Close()
+		resp, doErr = c.httpClient.Do(req)
+		if doErr != nil {
+			if !isRetryable(doErr, 0) {
+				return "", Usage{}, fmt.Errorf("request failed: %w", doErr)
+			}
+			continue
+		}
 
-	raw, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return "", Usage{}, fmt.Errorf("read response failed: %w", err)
-	}
+		raw, doErr = io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if doErr != nil {
+			return "", Usage{}, fmt.Errorf("read response failed: %w", doErr)
+		}
+		doErr = nil
 
+		if !isRetryable(nil, resp.StatusCode) {
+			break
+		}
+	}
+	if doErr != nil {
+		return "", Usage{}, fmt.Errorf("request failed: %w", doErr)
+	}
 	if resp.StatusCode != http.StatusOK {
 		return "", Usage{}, fmt.Errorf("server returned %d: %s", resp.StatusCode, raw)
 	}

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -1,11 +1,17 @@
 package llm
 
 import (
+	"context"
 	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestBuildImageContent_URL(t *testing.T) {
@@ -368,5 +374,142 @@ func TestWriteOutput_DirNotFound(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "output_file") {
 		t.Errorf("expected error to contain 'output_file', got: %v", err)
+	}
+}
+
+func TestIsRetryable_5xx(t *testing.T) {
+	for _, code := range []int{500, 502, 503, 504} {
+		if !isRetryable(nil, code) {
+			t.Errorf("expected 5xx %d to be retryable", code)
+		}
+	}
+}
+
+func TestIsRetryable_NonRetryableStatus(t *testing.T) {
+	for _, code := range []int{0, 200, 400, 404, 422} {
+		if isRetryable(nil, code) {
+			t.Errorf("expected status %d to be non-retryable", code)
+		}
+	}
+}
+
+func TestIsRetryable_ConnectionRefused(t *testing.T) {
+	err := fmt.Errorf("dial tcp: connection refused")
+	if !isRetryable(err, 0) {
+		t.Error("expected connection refused error to be retryable")
+	}
+}
+
+func TestIsRetryable_NilError_ZeroStatus(t *testing.T) {
+	if isRetryable(nil, 0) {
+		t.Error("nil error with zero status should not be retryable")
+	}
+}
+
+func TestIsRetryable_NonNetworkError(t *testing.T) {
+	err := fmt.Errorf("some other error")
+	if isRetryable(err, 0) {
+		t.Error("generic non-network error should not be retryable")
+	}
+}
+
+func TestCall_RetriesOn503ThenSucceeds(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := attempts.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	orig := retryDelays
+	retryDelays = [maxRetries]time.Duration{0, 0}
+	t.Cleanup(func() { retryDelays = orig })
+
+	text, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if text != "ok" {
+		t.Errorf("expected 'ok', got %q", text)
+	}
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts, got %d", attempts.Load())
+	}
+}
+
+func TestCall_ExhaustsRetries(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	orig := retryDelays
+	retryDelays = [maxRetries]time.Duration{0, 0}
+	t.Cleanup(func() { retryDelays = orig })
+
+	_, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error after exhausted retries")
+	}
+	if !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected 503 in error, got: %v", err)
+	}
+	if attempts.Load() != 3 {
+		t.Errorf("expected 3 attempts (1 + 2 retries), got %d", attempts.Load())
+	}
+}
+
+func TestCall_NoRetryOn4xx(t *testing.T) {
+	var attempts atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts.Add(1)
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	orig := retryDelays
+	retryDelays = [maxRetries]time.Duration{0, 0}
+	t.Cleanup(func() { retryDelays = orig })
+
+	_, _, err := c.Call(context.Background(), &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error on 400")
+	}
+	if attempts.Load() != 1 {
+		t.Errorf("expected exactly 1 attempt for 4xx, got %d", attempts.Load())
+	}
+}
+
+func TestCall_ContextCancelledDuringRetry(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	orig := retryDelays
+	retryDelays = [maxRetries]time.Duration{500 * time.Millisecond, 1 * time.Second}
+	t.Cleanup(func() { retryDelays = orig })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	_, _, err := c.Call(ctx, &Input{Prompt: "hello"})
+	if err == nil {
+		t.Fatal("expected error from cancelled context")
+	}
+	if !strings.Contains(err.Error(), "context") && !strings.Contains(err.Error(), "503") {
+		t.Errorf("expected context or 503 error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `isRetryable(err, statusCode)` helper in `internal/llm/client.go`
- Wrap HTTP dispatch in `Call()` with retry loop: max 2 retries, delays [200ms, 1s]
- Retry on HTTP 5xx, `net.Error.Temporary()`, and `"connection refused"` errors
- Non-retryable: 4xx, context cancellation, read errors
- No new configuration surface (hardcoded constants)

Closes #21

## Test plan

- [x] `TestIsRetryable_*` — unit tests for retry condition helper
- [x] `TestCall_RetriesOn503ThenSucceeds` — 2× 503 then 200 → success
- [x] `TestCall_ExhaustsRetries` — 3× 503 → error with 503 in message
- [x] `TestCall_NoRetryOn4xx` — 400 → exactly 1 attempt
- [x] `TestCall_ContextCancelledDuringRetry` — context timeout during backoff sleep