### PR TITLE
feat: debounce usage save and stat-first file size check (issue #23)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 .mcp.json
 .claude/settings.local.json
 .worktrees/
+*.wav

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"strconv"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -24,10 +26,14 @@ var (
 const (
 	defaultBaseURL = "http://localhost:8000"
 	defaultModel   = "mlx-community/gemma-4-26b-a4b-it-4bit"
+	saverInterval  = 30 * time.Second
 )
+
+type llmUsage = llm.Usage
 
 type usageStats struct {
 	mu               sync.Mutex
+	dirty            bool
 	TotalCalls       int `json:"total_calls"`
 	PromptTokens     int `json:"prompt_tokens"`
 	CompletionTokens int `json:"completion_tokens"`
@@ -52,13 +58,14 @@ func loadUsage(path string) *usageStats {
 	return s
 }
 
-func (s *usageStats) add(u llm.Usage) {
+func (s *usageStats) add(u llmUsage) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.TotalCalls++
 	s.PromptTokens += u.PromptTokens
 	s.CompletionTokens += u.CompletionTokens
 	s.TotalTokens += u.TotalTokens
+	s.dirty = true
 }
 
 func (s *usageStats) save(path string) error {
@@ -75,10 +82,42 @@ func (s *usageStats) save(path string) error {
 	return os.Rename(tmp, path)
 }
 
+func (s *usageStats) flushIfDirty(path string) {
+	s.mu.Lock()
+	if !s.dirty {
+		s.mu.Unlock()
+		return
+	}
+	s.dirty = false
+	s.mu.Unlock()
+	if err := s.save(path); err != nil {
+		log.Printf("usage save: %v", err)
+	}
+}
+
 func (s *usageStats) snapshot() (calls, prompt, completion, total int) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return s.TotalCalls, s.PromptTokens, s.CompletionTokens, s.TotalTokens
+}
+
+func startSaver(stats *usageStats, path string, interval time.Duration) (stop func()) {
+	quit := make(chan struct{})
+	var once sync.Once
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				stats.flushIfDirty(path)
+			case <-quit:
+				stats.flushIfDirty(path)
+				return
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(quit) }) }
 }
 
 func envOr(key, fallback string) string {
@@ -177,7 +216,6 @@ func main() {
 			}, nil, nil
 		}
 		stats.add(usage)
-		_ = stats.save(usagePath)
 		result := text + fmt.Sprintf("\n\n[usage: prompt=%d, completion=%d, total=%d]",
 			usage.PromptTokens, usage.CompletionTokens, usage.TotalTokens)
 		return &mcp.CallToolResult{
@@ -197,12 +235,26 @@ func main() {
 		}, nil, nil
 	})
 
+	stop := startSaver(stats, usagePath, saverInterval)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
 	ctx := context.Background()
 	session, err := s.Connect(ctx, &mcp.StdioTransport{}, nil)
 	if err != nil {
 		log.Fatalf("connect failed: %v", err)
 	}
-	if err := session.Wait(); err != nil {
-		log.Fatalf("session error: %v", err)
+
+	done := make(chan error, 1)
+	go func() { done <- session.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Printf("session error: %v", err)
+		}
+	case <-sigCh:
 	}
+	stop()
 }

--- a/cmd/mcp-local-llm/main_test.go
+++ b/cmd/mcp-local-llm/main_test.go
@@ -1,0 +1,107 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFlushIfDirty_WritesWhenDirty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15})
+
+	s.flushIfDirty(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to be written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty usage file")
+	}
+}
+
+func TestFlushIfDirty_SkipsWhenClean(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	// do NOT call add() — dirty stays false
+
+	s.flushIfDirty(path)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected no file written when not dirty")
+	}
+}
+
+func TestFlushIfDirty_ClearsDirtyAfterWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2})
+
+	s.flushIfDirty(path)
+	// dirty should now be false — second flush should not write again
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	s.flushIfDirty(path)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected no second write after dirty cleared")
+	}
+}
+
+func TestStartSaver_FlushesOnStop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5})
+
+	stop := startSaver(s, path, 10*time.Minute) // long interval — flush only on stop
+	stop()
+	time.Sleep(20 * time.Millisecond) // allow goroutine to complete
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file written on stop: %v", err)
+	}
+}
+
+func TestStartSaver_FlushesOnTick(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 7, CompletionTokens: 3, TotalTokens: 10})
+
+	stop := startSaver(s, path, 10*time.Millisecond)
+	defer stop()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return // file written — test passes
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error("expected file to be written within 500ms on tick")
+}
+
+func TestStartSaver_StopIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	stop := startSaver(s, path, time.Minute)
+
+	// calling stop twice must not panic
+	stop()
+	stop()
+}

--- a/docs/VLLM_API.md
+++ b/docs/VLLM_API.md
@@ -301,12 +301,24 @@ OpenAI TTS API 호환. JSON body 전송.
 | 파라미터 | 타입 | 기본값 | 설명 |
 |---------|------|--------|------|
 | `model` | string | `kokoro` | TTS 모델 별칭 |
-| `input` | string | 필수 | 합성할 텍스트 |
+| `input` | string | 필수 | 합성할 텍스트 (길이 한도는 아래 참고) |
 | `voice` | string | `af_heart` | 음성 ID (모델별 상이) |
 | `speed` | float | `1.0` | 속도 (0.5~2.0) |
 | `response_format` | string | `wav` | `wav` 또는 `mp3` |
 | `lang_code` | string | `a` | 언어 코드 |
 | `volume` | float | `0.9` | 출력 음량 (0.0~1.0). RMS 정규화 후 적용 |
+
+**`input` 길이 한도:**
+
+- 서버 설정에 따라 상한이 정해진다. 기본 구성 예: **`input`은 최대 4096자**까지(초과 시 합성하지 않음).
+- 한도 초과 시 **HTTP 413**, 본문 예:
+
+```json
+{"detail":"TTS input too long: 4097 characters exceeds the configured limit of 4096 characters."}
+```
+
+- 모델·언어·목소리(`kokoro`, `chatterbox-multilingual`, `iu` 등)와 무관하게 **동일 한도**가 적용되는 경우가 일반적이다. 실제 값은 `/v1/status` 또는 서버 설정을 확인하거나, 경계 길이로 요청해 응답 코드를 보면 된다.
+- 출력 오디오 **재생 시간**은 글자 수·문장·`speed`·모델에 따라 달라지며, `input` 한도와 별개다. 긴 음성은 텍스트를 나눠 여러 번 호출한 뒤 파일을 이어붙이는 방식을 검토한다.
 
 **지원 모델:**
 

--- a/docs/VLLM_API_summary.md
+++ b/docs/VLLM_API_summary.md
@@ -12,7 +12,7 @@ vllm-mlx 서버에서 제공하는 모든 API 엔드포인트를 카테고리별
 | **채팅 (Anthropic)** | POST | `/v1/messages/count_tokens` | 입력 토큰 수 계산 |
 | **텍스트 완성** | POST | `/v1/completions` | 레거시 텍스트 완성 (OpenAI 호환) |
 | **STT (음성 인식)** | POST | `/v1/audio/transcriptions` | 음성 파일을 텍스트로 변환 |
-| **TTS (음성 합성)** | POST | `/v1/audio/speech` | 텍스트를 음성으로 변환 |
+| **TTS (음성 합성)** | POST | `/v1/audio/speech` | 텍스트를 음성으로 변환 (`input` 최대 글자수는 서버 설정; 초과 시 413. 예: 4096자) |
 | **TTS (음성 합성)** | GET | `/v1/audio/voices` | 사용 가능한 TTS 목소리 목록 조회 |
 | **MCP** | GET | `/v1/mcp/tools` | 연결된 MCP 서버의 도구 목록 조회 |
 | **MCP** | GET | `/v1/mcp/servers` | 연결된 MCP 서버 목록 조회 |

--- a/docs/improvements-llm-client-mcp.md
+++ b/docs/improvements-llm-client-mcp.md
@@ -1,0 +1,195 @@
+# mcp-local-llm — 본질적 개선 후보
+
+이 문서는 MCP 서버 툴 호출 경로와 `internal/llm` 클라이언트에서 **성능·신뢰성·메모리**에 실질적 영향이 있는 개선 아이디어를 정리한 것이다. 순서만 바꾸는 수준의 리팩터링은 제외했다.
+
+---
+
+## 1. `usage.json` 매 호출 디스크 저장 — 핵심 경로의 불필요한 I/O
+
+**위치:** [`cmd/mcp-local-llm/main.go`](../cmd/mcp-local-llm/main.go) — `call_local_llm` 툴 핸들러에서 매 LLM 호출마다 `stats.save(usagePath)` 호출.
+
+**현재 동작:** `WriteFile(.tmp)` + `Rename` 등이 응답 반환 직전에 동기 실행된다.
+
+**문제:**
+
+- 동시 호출 시 `save()`가 뮤텍스 해제 뒤 파일 I/O를 수행하면, 여러 고루틴이 같은 파일에 경쟁적으로 쓰기 → **마지막 쓰기 승, 카운트 손실 가능**.
+- 핵심 경로에서 저장 오류를 `_`로 무시해 **안전성·관측 가능성**이 낮다.
+
+**개선 방향:**
+
+- **디바운스 / 주기 저장:** 별도 고루틴에서 N초마다, 변경이 있을 때만 저장. 툴 핸들러 핵심 경로에서는 `save` 제거.
+- **Graceful shutdown:** `signal.Notify(SIGINT/SIGTERM)` 후 마지막 flush. 디바운스 도입 시 프로세스 종료 시 통계 유실 방지에 필요.
+
+---
+
+## 2. 이미지 base64 인코딩의 메모리 이중·삼중 점유
+
+**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `readImageAsDataURI` (파일 전체 `io.ReadAll` → `base64.StdEncoding.EncodeToString` → `chatRequest` JSON marshal).
+
+**현재 동작:** 큰 이미지일수록 원본 바이트 + base64 문자열 + JSON 바디까지 피크 메모리가 커진다 (예: 5MB 이미지면 대략 15MB+ 수준까지 가능).
+
+**개선 방향:**
+
+- **`io.Pipe` + `base64.NewEncoder`** 로 HTTP 요청 본문에 스트리밍하여 중간 대형 문자열 할당을 줄인다.
+- 또는 최소한 **사전 크기 계산 후 단일 `[]byte` 버퍼**에 인코딩해 `EncodeToString`의 추가 할당을 줄인다.
+- **`LOCAL_LLM_MAX_IMAGES`** 기본값(예: 5)과 함께 쓰일 때 효과가 배로 커진다.
+
+---
+
+## 3. 트랜션트 오류 재시도 부재 — 신뢰성
+
+**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `http.Client.Do` 실패 또는 5xx 응답 시 즉시 에러 반환.
+
+**문제:** vllm-mlx가 일시적으로 불안정할 때(5xx, KV/OOM 직후, 연결 거절 등) MCP 사용자에게 바로 실패로 전달된다.
+
+**개선 방향:**
+
+- **Bounded retry:** 5xx, 일시적 `net.Error`, `connection refused` 등에 한해 최대 2회, 200ms → 1s 정도 백오프.
+- POST이지만 동일 프롬프트 재시도는 운영상 허용 가능한 경우가 많다(출력은 원래 비결정적).
+- **`context.Context` 취소** 시 재시도 중단.
+
+---
+
+## 4. 입력 토큰 사전 추정 — 서버 OOM/한도 초과 완화
+
+**배경:** 긴 입력 + 큰 `max_tokens` 조합에서 vllm-mlx(Metal) OOM 등이 클라이언트에서 사전에 막기 어렵다.
+
+**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `Call()` 진입부 근처.
+
+**개선 방향:**
+
+- `prompt` + `input_files` 내용 + `system` 등 **합산 문자 수**로 토큰을 거칠게 추정 (예: `chars / 3.5`).
+- **`LOCAL_LLM_SERVER_TOKEN_LIMIT`** (또는 유사 이름) 환경 변수로 서버가 허용하는 **요청 전체 토큰 상한**을 받는다.
+- `추정 입력 토큰 + (요청 max_tokens 또는 기본 max_tokens) > 한도`이면 **요청 전 명시적 에러**로 거절해, 서버 프로세스를 죽이는 패턴을 줄인다.
+
+---
+
+## 5. `buildPromptWithFiles` — 한도 초과로 거절될 파일도 전부 읽음
+
+**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `buildPromptWithFiles`: `os.ReadFile` 후 누적 바이트가 `maxBytes`를 넘으면 에러.
+
+**문제:** 단일 대용량 파일이면 **전부 읽은 뒤**에야 초과를 감지할 수 있어 I/O·메모리 낭비.
+
+**개선 방향:**
+
+- **1패스:** `os.Stat`으로 각 파일 크기 합산 → `maxBytes` 초과 시 즉시 에러.
+- **2패스:** 통과한 경우에만 `os.ReadFile`로 내용 로드.
+
+---
+
+## 6. 세마포어 획득 순서 — 저비용 검증이 LLM 슬롯 뒤로 밀림
+
+**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `Call()`에서 동시성 세마포어를 먼저 잡고, 그 다음 `validatePath` 등을 수행.
+
+**문제:** 잘못된 경로 등 **즉시 실패** 케이스가 활성 LLM 요청 뒤에 대기할 수 있다 (`LOCAL_LLM_MAX_CONCURRENT` 사용 시).
+
+**개선 방향:**
+
+- 경로 검증·파일 존재 등 **저비용·결정적 검증**을 세마포어 획득 **이전**에 수행하고, HTTP 호출 직전에만 세마포어를 잡는 구조로 재배치한다.
+
+---
+
+## 7. `max_tokens`·로컬 추론 한계 — 출력 연속 완성(continuation)과 입력 분할의 구분
+
+**위치(예상):** [`internal/llm/client.go`](../internal/llm/client.go) — `Call()` 및 (도입 시) 내부 전용 연속 완성 헬퍼.
+
+**현재 동작:**
+
+- `Call()`은 **단일** `POST /v1/chat/completions` 호출이다. `max_tokens`는 그 한 번의 **출력 상한**만 지정한다.
+- 요청 `max_tokens`가 **서버가 허용하는 최대값을 초과**하면(로컬 MLX 스택 등에서 관측) **HTTP 400**으로 거절되며, 클라이언트는 **자동 분할·재요청을 하지 않는다**.
+- `max_tokens`가 한도 **이하**이면 생성은 해당 토큰에서 **잘린 채** 응답으로 돌아오고, **추가 라운드 없이** 그 문자열이 그대로 반환 경로로 이어진다.
+
+**문제:**
+
+- 로컬 LLM의 성능·메모리 제약 때문에 운영상 `max_tokens`를 **낮게** 두는 경우가 많고, 그때 **긴 답**은 한 번의 완성으로는 끝까지 나오지 않는다.
+- 사용자가 기대하는 “청킹”에 가깝게 해결하려면, 같은 논리적 요청을 **여러 번의 completion으로 이어 붙이는 출력 연속 완성(continuation)** 이 자연스럽다. 이는 **입력**을 잘라 여러 번 보내는 것과 목적·난이도가 다르다(아래 표).
+
+**개선 방향 — 출력(1차 범위):**
+
+- **Continuation 루프:** 1차 응답 후, 메시지 히스토리에 `assistant`(지금까지의 생성물)를 넣고 `user`에 고정 문구(예: 이어서 출력, 잘린 지점부터 계속)를 추가해 **같은 모델에 재요청**한다. 구현은 공개 `Call`을 N번 호출하거나, 내부 전용 헬퍼로 묶을 수 있다.
+- **중단 조건:** 최대 **라운드 수**, **누적 출력 토큰·문자 상한**, 연속 **빈 증분** 등. `finish_reason`이나 `usage.completion_tokens`와 요청 `max_tokens`의 관계로 “한도에 도달했는지”를 보조 판단할 수 있으나, **MLX 등에서는 `finish_reason`이 항상 `length`로 오지 않을 수 있어** 단일 신호에 의존하지 않는 편이 안전하다.
+- **Gemma thinking:** 라운드마다 `<|channel>thought…<channel|>` 블록이 붙을 수 있다. **라운드별로 thinking 제거(현재 또는 향후 `FilterThinking`과 동등한 처리) 후 문자열만 누적**하거나, continuation 전용 시스템/지시문으로 형식을 안정화하는 방안을 검토한다.
+- **환경 변수(제안):** 예) `LOCAL_LLM_OUTPUT_CHUNK_ENABLED`(기본 `false`), `LOCAL_LLM_OUTPUT_CHUNK_MAX_ROUNDS`. 기본은 끄고 **옵트인**이 안전하다(지연·부하·비결정적 출력 증가).
+- **MCP 계약:** `call_local_llm` **한 번**의 툴 호출이 내부적으로 **N번** HTTP를 사용할 수 있게 되므로, README·툴 설명에서 기대치를 맞춘다.
+
+**입력 토큰도 같은 “청킹”으로 처리해야 하는가?**
+
+| 구분 | 자동 청킹(연속 호출)이 직접 맞는가 | 비고 |
+|------|-------------------------------------|------|
+| **출력** (`max_tokens` 등으로 **생성이 잘림**) | **예** — continuation이 정면 해법 | §7의 1차 설계 범위 |
+| **입력** (프롬프트+파일이 **모델 컨텍스트 한도**에 근접) | **별도 문제** — 프롬프트를 잘라 **순서 없이** 여러 번만 보내면 최종 답을 합성할 수 없다 | **맵리듀스**(청크 요약 후 최종 합성), **RAG**, **일부만 포함**, 또는 **§4**의 사전 추정·거절과 연계한 운영이 자연스럽다 |
+| **입력** (**§5** `buildPromptWithFiles`·`LOCAL_LLM_MAX_INPUT_BYTES` 등 **클라이언트 한도**) | 현재는 **거절**이 맞고, “자동 분할”은 **정책**(파일 순서, 중간 결과 저장 위치)이 필요 | **§5**·**§4**와 같은 축; continuation 메커니즘으로 대체되지 않는다 |
+
+**결론:** 자동 청킹 설계의 **1차 범위는 출력 연속 완성**으로 두고, 입력 한도·컨텍스트 문제는 **§4·§5**와 연계한 **사전 검증**과, 필요 시 **§8**의 **입력 맵리듀스**로 다룬다.
+
+---
+
+## 8. 큰 `input_files`(비이미지) 자동 분할·맵리듀스 분석
+
+**위치(예상):** [`internal/llm/client.go`](../internal/llm/client.go) — `buildPromptWithFiles` 호출 전·대체 경로, 또는 `Call()` 내부에서 파일 합산 크기·타입에 따라 분기.
+
+**배경:** 이미지가 아닌 **텍스트·코드·마크다운** 등은 바이트/문자 경계로 잘라도, 청크마다 부분 분석 후 합치는 **맵리듀스** 패턴이 현실적이다(§7 표의 “입력 컨텍스트” 행과 연결). **이미지**는 한 장 단위가 아니면 의미 단위가 깨져 **본 §8의 기본 대상에서 제외**하는 편이 낫다. **오디오·STT**는 `chat`이 아니라 **`/v1/audio/transcriptions`** 축이므로 **§9**에서 다룬다.
+
+**현재 동작:**
+
+- `input_files`는 전부 읽어 프롬프트에 붙이고 **한 번**만 LLM에 보낸다. `LOCAL_LLM_MAX_INPUT_BYTES` 초과 시 **거절**한다(§5). 모델 컨텍스트·OOM은 클라이언트가 사전에 맞추지 않는다(§4).
+
+**개선 방향:**
+
+- **맵 단계:** 사용자 `prompt`와 “이 파일의 i/N 청크”·겹침(overlap) 옵션을 넣어 **청크당 한 번** completion 호출. 청크 크기는 바이트/문자(구현 단순) 또는 **§4**와 같은 **대략 토큰 추정** 기준 중 선택.
+- **리듀스 단계:** 맵 단계 산출(요약·추출)을 모아 **최종 질의 한 번**(또는 계층적 리듀스)으로 전체 답을 생성.
+- **한도 정책:** “원본 전체 허용량” vs “청크당 상한”을 env로 분리해, 기존 `LOCAL_LLM_MAX_INPUT_BYTES` 의미와 충돌하지 않게 문서화한다.
+- **바이너리:** 압축·실행 파일 등은 텍스트처럼 자른 분석이 무의미할 수 있어 **확장자/스니핑으로 분할 대상 제외**하거나, 분할 시 “원시 바이트 나열”임을 명시하는 등 보수적 기본값을 둔다.
+- **환경 변수(제안):** 예) `LOCAL_LLM_INPUT_MAPREDUCE_ENABLED`(기본 `false`), `LOCAL_LLM_INPUT_CHUNK_BYTES`, `LOCAL_LLM_INPUT_CHUNK_OVERLAP_BYTES`, `LOCAL_LLM_INPUT_MAPREDUCE_MAX_CHUNKS`. **옵트인**으로 두어 호출 수·지연·비결정성을 사용자가 감수하도록 한다.
+- **§7과의 관계:** 출력 **continuation**과 조합하면 내부 HTTP 횟수가 더 늘어난다. README·툴 설명에 “단일 `call_local_llm`이 다회 호출될 수 있음”을 **입력 분할** 차원에서도 명시한다.
+
+---
+
+## 9. MCP에 STT·TTS 연동 (로컬 `VLLM_API` 오디오 엔드포인트)
+
+**참고 스펙:** [`docs/VLLM_API.md`](VLLM_API.md) — 채팅과 **동일 베이스 URL**(`LOCAL_LLM_BASE_URL`)에서 OpenAI 호환 오디오 API를 제공한다.
+
+**배경:** 음성은 `chat/completions` 텍스트·이미지 경로와 다르다. STT는 **`POST /v1/audio/transcriptions`**(multipart 파일 업로드), TTS는 **`POST /v1/audio/speech`**(JSON 입력·바이너리 응답). 추후 MCP에 도구로 노출할 때 **별도 HTTP 클라이언트 헬퍼**와 **툴 스키마**가 필요하다.
+
+**현재 동작:**
+
+- [`internal/llm/client.go`](../internal/llm/client.go) / `call_local_llm`은 **채팅 완성만** 다룬다. STT·TTS 호출은 없음.
+
+**개선 방향 — STT (음성 → 텍스트):**
+
+- **단일 파일:** `workDir` 하위 오디오 경로 검증(기존 `validatePath` 패턴) 후 `multipart/form-data`로 `file`, `model`(문서상 `whisper-1`), 선택 `language` 전송. 응답 JSON의 `text`를 툴 결과로 반환하거나, 이어서 `Call()`에 넣을 수 있게 **옵션**을 둔다.
+- **긴 녹음 분할:** API는 “파일 하나당 한 번 전사” 모델이므로, **클라이언트가** 시간 구간 등으로 오디오를 나눈 뒤 **transcriptions를 N번 호출**하고 문자열을 병합한다(§8 맵 단계와 **오케스트레이션만 유사**, 엔드포인트는 다름). 겹침·문장 경계·최대 세그먼트 수는 env로 제한.
+- **환경 변수(제안):** 예) `LOCAL_LLM_STT_CHUNK_SECONDS`, `LOCAL_LLM_STT_MAX_SEGMENTS`, 분할 사용 시 옵트인 플래그. ffmpeg 등 **외부 바이너리 의존** 여부는 구현 시 명시.
+
+**개선 방향 — TTS (텍스트 → 음성):**
+
+- JSON 바디(`model`, `input`, `voice`, `response_format`, `lang_code` 등 — [`VLLM_API.md`](VLLM_API.md) 표 준수)로 **`POST /v1/audio/speech`** 호출, 응답 바이너리를 **`output_file` 동일 규칙**으로 `workDir` 안 경로에 저장하거나, base64/data URL 반환 여부는 툴 설계에서 결정(대용량은 파일 저장이 MCP·Claude 쪽에 유리).
+- 채팅 `max_tokens`·thinking 필터와 **무관**; 타임아웃만 공유 가능.
+
+**MCP 설계 선택:**
+
+- **`call_local_llm` 확장**보다 **`call_local_stt` / `call_local_tts`(가칭) 분리**를 권장한다 — 파라미터·응답 형식이 달라 스키마가 단순해지고, 채팅 usage 집계와도 분리하기 쉽다.
+- 툴 추가 시 [`cmd/mcp-local-llm/main.go`](../cmd/mcp-local-llm/main.go)의 `AddTool`·usage 저장 경로를 따라가고, [`README.md`](../README.md)·[`.env.example`](../.env.example)에 베이스 URL 재사용과 신규 env를 반영한다 ([`CLAUDE.md`](../CLAUDE.md)).
+
+**§8과의 구분:** §8은 **텍스트 파일** 맵리듀스; 본 §9는 **오디오 → 전사 → (선택) LLM** 파이프라인. 동일 녹음에 대해 “전사만” vs “전사 후 Gemma 분석”은 별 툴 호출 또는 단일 툴의 플래그로 나눌 수 있다.
+
+---
+
+## 구현 시 참고
+
+- 환경 변수 추가 시 [`README.md`](../README.md) Configuration 표와 예시를 갱신한다 ([`CLAUDE.md`](../CLAUDE.md) 워크플로 규칙).
+- STT·TTS 도구 도입 시에도 동일하며, **바이너리 응답·multipart 요청**은 Inspector/클라이언트 호환성을 README에 한 줄이라도 적어두면 좋다.
+- `LOCAL_LLM_SERVER_TOKEN_LIMIT` 같은 값은 **추정치 기반**이므로 에러 메시지에 “대략적 추정”임을 명시하는 것이 좋다.
+- 디바운스 저장 도입 시 **프로세스 강제 종료(SIGKILL)** 에는 flush가 보장되지 않음을 문서에 적어두면 된다.
+
+---
+
+## 관련 파일
+
+| 영역 | 파일 |
+|------|------|
+| MCP 툴, usage 저장 | `cmd/mcp-local-llm/main.go` |
+| HTTP 클라이언트, 프롬프트/이미지/필터 | `internal/llm/client.go` |
+| STT·TTS HTTP (예정) | `internal/llm/` 신규 또는 `client.go` 인접 패키지 — §9 |
+| 로컬 오디오 API 스펙 | `docs/VLLM_API.md` |
+| 기존 단위 테스트 | `internal/llm/client_test.go` |

--- a/docs/superpowers/plans/2026-05-04-debounce-and-stat-first.md
+++ b/docs/superpowers/plans/2026-05-04-debounce-and-stat-first.md
@@ -1,0 +1,670 @@
+# §1 Debounce Save + §5 Stat-First Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove synchronous I/O from the LLM hot path (§1 debounce) and avoid reading large files before size-limit rejection (§5 stat-first).
+
+**Architecture:** §5 replaces `buildPromptWithFiles`'s single read-then-check loop with a 2-pass stat-first approach. §1 adds a `dirty` flag to `usageStats`, a `flushIfDirty` method, a `startSaver` ticker goroutine, and graceful shutdown via `signal.Notify` in `main()`. Both changes are independent and committed separately.
+
+**Tech Stack:** Go stdlib — `os`, `sync`, `time`, `os/signal`, `syscall`
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `internal/llm/client.go:177-218` | Replace `buildPromptWithFiles` with 2-pass implementation |
+| `internal/llm/client_test.go` | Add stat-first tests |
+| `cmd/mcp-local-llm/main.go` | Add `dirty` field, `flushIfDirty`, `startSaver`, update `main()` |
+| `cmd/mcp-local-llm/main_test.go` | New — unit tests for `flushIfDirty` and `startSaver` |
+
+---
+
+### Task 1: GitHub issue + feature branch
+
+**Files:** none
+
+- [ ] **Step 1: Create GitHub issue**
+
+```bash
+gh issue create \
+  --title "feat: debounce usage.json save and stat-first file size check" \
+  --body "$(cat <<'EOF'
+## §1 — Debounce usage.json save
+
+`stats.save()` is called synchronously on every LLM call with error ignored. Add a 30s debounce goroutine, dirty flag, and SIGINT/SIGTERM graceful flush instead.
+
+## §5 — stat-first in buildPromptWithFiles
+
+`buildPromptWithFiles` reads every file fully before checking the size limit. Add an os.Stat pass first — reject immediately if the total size exceeds the limit, then read only on pass.
+EOF
+)"
+```
+
+Note the issue number (e.g. `#22`).
+
+- [ ] **Step 2: Create feature branch**
+
+Replace `{N}` with the actual issue number:
+
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b feat/issue-{N}-debounce-and-stat-first
+```
+
+---
+
+### Task 2: §5 failing tests
+
+**Files:**
+- Modify: `internal/llm/client_test.go`
+
+- [ ] **Step 1: Add failing tests for stat-first behavior**
+
+Append to `internal/llm/client_test.go`:
+
+```go
+func TestBuildPromptWithFiles_StatFirstRejectsBeforeRead(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a file large enough to exceed limit on its own
+	large := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(large, []byte(strings.Repeat("x", 200)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := buildPromptWithFiles("prompt", []string{large}, 50)
+	if err == nil {
+		t.Fatal("expected error when single file exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected 'exceeds limit', got: %v", err)
+	}
+}
+
+func TestBuildPromptWithFiles_StatFirstSumExceedsLimit(t *testing.T) {
+	dir := t.TempDir()
+
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(f1, []byte(strings.Repeat("a", 60)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte(strings.Repeat("b", 60)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := buildPromptWithFiles("prompt", []string{f1, f2}, 100)
+	if err == nil {
+		t.Fatal("expected error when combined size exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected 'exceeds limit', got: %v", err)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests — confirm they pass (stat-first doesn't change observable behavior for these cases)**
+
+```bash
+cd /Volumes/dev-disk/dev-workspace/mcp-local-llm
+go test ./internal/llm/ -run TestBuildPromptWithFiles_Stat -v
+```
+
+Expected: PASS — these tests verify the *result*, not the mechanism. They pass with the current code too and will keep passing after the refactor.
+
+---
+
+### Task 3: §5 implementation — stat-first in buildPromptWithFiles
+
+**Files:**
+- Modify: `internal/llm/client.go:177-218`
+
+- [ ] **Step 1: Replace buildPromptWithFiles with 2-pass version**
+
+Current function at lines 177–218:
+
+```go
+func buildPromptWithFiles(prompt string, files []string, maxBytes int) (string, error) {
+	if len(files) == 0 {
+		return prompt, nil
+	}
+	type fileData struct {
+		path    string
+		content []byte
+	}
+	var total int
+	loaded := make([]fileData, 0, len(files))
+	for i, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("input_files[%d]: file not found: %s", i, path)
+			}
+			if os.IsPermission(err) {
+				return "", fmt.Errorf("input_files[%d]: permission denied: %s", i, path)
+			}
+			return "", fmt.Errorf("input_files[%d]: read failed: %w", i, err)
+		}
+		total += len(data)
+		if maxBytes > 0 && total > maxBytes {
+			return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
+				"Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
+		}
+		loaded = append(loaded, fileData{path: path, content: data})
+	}
+	var sb strings.Builder
+	sb.WriteString(prompt)
+	for _, f := range loaded {
+		sb.WriteString("\n\n[file: ")
+		sb.WriteString(f.path)
+		sb.WriteString("]\n")
+		sb.Write(f.content)
+	}
+	result := sb.String()
+	if len(result) > 0 && result[len(result)-1] != '\n' {
+		result += "\n"
+	}
+	return result, nil
+}
+```
+
+Replace with:
+
+```go
+func buildPromptWithFiles(prompt string, files []string, maxBytes int) (string, error) {
+	if len(files) == 0 {
+		return prompt, nil
+	}
+	// Pass 1: stat only — reject before reading if total size exceeds limit
+	var total int64
+	for i, path := range files {
+		info, err := os.Stat(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				return "", fmt.Errorf("input_files[%d]: file not found: %s", i, path)
+			}
+			return "", fmt.Errorf("input_files[%d]: stat failed: %w", i, err)
+		}
+		total += info.Size()
+		if maxBytes > 0 && total > int64(maxBytes) {
+			return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
+				"Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
+		}
+	}
+	// Pass 2: read all files (size already validated)
+	var sb strings.Builder
+	sb.WriteString(prompt)
+	for i, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsPermission(err) {
+				return "", fmt.Errorf("input_files[%d]: permission denied: %s", i, path)
+			}
+			return "", fmt.Errorf("input_files[%d]: read failed: %w", i, err)
+		}
+		sb.WriteString("\n\n[file: ")
+		sb.WriteString(path)
+		sb.WriteString("]\n")
+		sb.Write(data)
+	}
+	result := sb.String()
+	if len(result) > 0 && result[len(result)-1] != '\n' {
+		result += "\n"
+	}
+	return result, nil
+}
+```
+
+- [ ] **Step 2: Run all client tests**
+
+```bash
+go test ./internal/llm/ -v
+```
+
+Expected: all PASS (error message text preserved — existing tests check `"file not found"`, `"exceeds limit"` which are unchanged).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/llm/client.go internal/llm/client_test.go
+git commit -m "feat: stat-first size check in buildPromptWithFiles"
+```
+
+---
+
+### Task 4: §1 failing tests — flushIfDirty and startSaver
+
+**Files:**
+- Create: `cmd/mcp-local-llm/main_test.go`
+
+- [ ] **Step 1: Create test file**
+
+Create `cmd/mcp-local-llm/main_test.go`:
+
+```go
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFlushIfDirty_WritesWhenDirty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15})
+
+	s.flushIfDirty(path)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("expected file to be written: %v", err)
+	}
+	if len(data) == 0 {
+		t.Error("expected non-empty usage file")
+	}
+}
+
+func TestFlushIfDirty_SkipsWhenClean(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	// do NOT call add() — dirty stays false
+
+	s.flushIfDirty(path)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected no file written when not dirty")
+	}
+}
+
+func TestFlushIfDirty_ClearsDirtyAfterWrite(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 1, CompletionTokens: 1, TotalTokens: 2})
+
+	s.flushIfDirty(path)
+	// dirty should now be false — second flush should not write again
+	if err := os.Remove(path); err != nil {
+		t.Fatal(err)
+	}
+	s.flushIfDirty(path)
+
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("expected no second write after dirty cleared")
+	}
+}
+
+func TestStartSaver_FlushesOnStop(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 3, CompletionTokens: 2, TotalTokens: 5})
+
+	stop := startSaver(s, path, 10*time.Minute) // long interval — flush only on stop
+	stop()
+	time.Sleep(20 * time.Millisecond) // allow goroutine to complete
+
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("expected file written on stop: %v", err)
+	}
+}
+
+func TestStartSaver_FlushesOnTick(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	s.add(llmUsage{PromptTokens: 7, CompletionTokens: 3, TotalTokens: 10})
+
+	stop := startSaver(s, path, 10*time.Millisecond)
+	defer stop()
+
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return // file written — test passes
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Error("expected file to be written within 500ms on tick")
+}
+
+func TestStartSaver_StopIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "usage.json")
+
+	s := &usageStats{}
+	stop := startSaver(s, path, time.Minute)
+
+	// calling stop twice must not panic
+	stop()
+	stop()
+}
+```
+
+Note: `llmUsage` is a type alias for `llm.Usage` that we'll define in Task 5. For now the tests won't compile.
+
+- [ ] **Step 2: Run tests — confirm they fail to compile**
+
+```bash
+go test ./cmd/mcp-local-llm/ -v 2>&1 | head -20
+```
+
+Expected: build failure — `flushIfDirty`, `startSaver`, `llmUsage` undefined.
+
+---
+
+### Task 5: §1 implementation — dirty flag + flushIfDirty
+
+**Files:**
+- Modify: `cmd/mcp-local-llm/main.go`
+
+- [ ] **Step 1: Add `dirty` field to `usageStats` and define `llmUsage` type alias**
+
+Current `usageStats` struct (lines 29–35):
+
+```go
+type usageStats struct {
+	mu               sync.Mutex
+	TotalCalls       int `json:"total_calls"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+```
+
+Replace with:
+
+```go
+type llmUsage = llm.Usage
+
+type usageStats struct {
+	mu               sync.Mutex
+	dirty            bool
+	TotalCalls       int `json:"total_calls"`
+	PromptTokens     int `json:"prompt_tokens"`
+	CompletionTokens int `json:"completion_tokens"`
+	TotalTokens      int `json:"total_tokens"`
+}
+```
+
+- [ ] **Step 2: Update `add()` to set dirty=true**
+
+Current `add()` method (lines 55–62):
+
+```go
+func (s *usageStats) add(u llm.Usage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.TotalCalls++
+	s.PromptTokens += u.PromptTokens
+	s.CompletionTokens += u.CompletionTokens
+	s.TotalTokens += u.TotalTokens
+}
+```
+
+Replace with:
+
+```go
+func (s *usageStats) add(u llmUsage) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.TotalCalls++
+	s.PromptTokens += u.PromptTokens
+	s.CompletionTokens += u.CompletionTokens
+	s.TotalTokens += u.TotalTokens
+	s.dirty = true
+}
+```
+
+- [ ] **Step 3: Add `flushIfDirty` method after `save()`**
+
+After the existing `save()` method (currently ending around line 76), add:
+
+```go
+func (s *usageStats) flushIfDirty(path string) {
+	s.mu.Lock()
+	if !s.dirty {
+		s.mu.Unlock()
+		return
+	}
+	s.dirty = false
+	s.mu.Unlock()
+	if err := s.save(path); err != nil {
+		log.Printf("usage save: %v", err)
+	}
+}
+```
+
+- [ ] **Step 4: Run tests — flushIfDirty tests should pass, startSaver still fails**
+
+```bash
+go test ./cmd/mcp-local-llm/ -run "TestFlushIfDirty" -v
+```
+
+Expected: all 3 `TestFlushIfDirty_*` tests PASS.
+
+---
+
+### Task 6: §1 implementation — startSaver
+
+**Files:**
+- Modify: `cmd/mcp-local-llm/main.go`
+
+- [ ] **Step 1: Add `saverInterval` constant and `startSaver` function**
+
+Add `"sync"` is already imported. Add `"os/signal"` and `"syscall"` to the import block:
+
+Current imports:
+```go
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"mcp-local-llm/internal/llm"
+)
+```
+
+Replace with:
+
+```go
+import (
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"mcp-local-llm/internal/llm"
+)
+```
+
+- [ ] **Step 2: Add `saverInterval` constant after the existing constants block**
+
+After `const ( defaultBaseURL = ... defaultModel = ... )`, add:
+
+```go
+const saverInterval = 30 * time.Second
+```
+
+- [ ] **Step 3: Add `startSaver` function**
+
+Add after `flushIfDirty`:
+
+```go
+func startSaver(stats *usageStats, path string, interval time.Duration) (stop func()) {
+	quit := make(chan struct{})
+	var once sync.Once
+	go func() {
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-t.C:
+				stats.flushIfDirty(path)
+			case <-quit:
+				stats.flushIfDirty(path)
+				return
+			}
+		}
+	}()
+	return func() { once.Do(func() { close(quit) }) }
+}
+```
+
+- [ ] **Step 4: Run startSaver tests**
+
+```bash
+go test ./cmd/mcp-local-llm/ -run "TestStartSaver" -v
+```
+
+Expected: all 3 `TestStartSaver_*` tests PASS.
+
+---
+
+### Task 7: §1 implementation — update main()
+
+**Files:**
+- Modify: `cmd/mcp-local-llm/main.go`
+
+- [ ] **Step 1: Remove hot-path save and add startSaver + signal handling**
+
+Current end of `main()` (lines 172–208, the tool handler and session block):
+
+In the `call_local_llm` tool handler, find and remove:
+```go
+		stats.add(usage)
+		_ = stats.save(usagePath)
+```
+
+Replace with:
+```go
+		stats.add(usage)
+```
+
+- [ ] **Step 2: Replace session.Wait() block with select-based shutdown**
+
+Current session block (last ~8 lines of main):
+
+```go
+	ctx := context.Background()
+	session, err := s.Connect(ctx, &mcp.StdioTransport{}, nil)
+	if err != nil {
+		log.Fatalf("connect failed: %v", err)
+	}
+	if err := session.Wait(); err != nil {
+		log.Fatalf("session error: %v", err)
+	}
+```
+
+Replace with:
+
+```go
+	stop := startSaver(stats, usagePath, saverInterval)
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+
+	ctx := context.Background()
+	session, err := s.Connect(ctx, &mcp.StdioTransport{}, nil)
+	if err != nil {
+		log.Fatalf("connect failed: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() { done <- session.Wait() }()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Printf("session error: %v", err)
+		}
+	case <-sigCh:
+	}
+	stop()
+```
+
+- [ ] **Step 3: Build and run all tests**
+
+```bash
+go test ./... -v 2>&1 | tail -20
+make build
+```
+
+Expected: all tests PASS, binary builds cleanly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add cmd/mcp-local-llm/main.go cmd/mcp-local-llm/main_test.go
+git commit -m "feat: debounce usage.json save with 30s ticker and graceful shutdown"
+```
+
+---
+
+### Task 8: PR
+
+**Files:** none
+
+- [ ] **Step 1: Push branch and open PR**
+
+Replace `{N}` with the actual issue number:
+
+```bash
+git push -u origin feat/issue-{N}-debounce-and-stat-first
+gh pr create \
+  --title "feat: debounce usage save and stat-first file size check (issue #{N})" \
+  --body "$(cat <<'EOF'
+## Summary
+
+### §5 — stat-first in buildPromptWithFiles
+- Replace single read-then-check loop with 2-pass: `os.Stat` size sum first, `os.ReadFile` only if within limit
+- Avoids reading large files that will be rejected anyway
+- Error messages unchanged (existing tests unaffected)
+
+### §1 — Debounce usage.json save
+- Add `dirty` flag to `usageStats`; `add()` sets it, `flushIfDirty()` clears after write
+- `startSaver` ticker goroutine flushes every 30s when dirty; `sync.Once`-protected stop
+- `main()` registers `SIGINT`/`SIGTERM`; either signal or session end triggers `stop()` → final flush
+- Remove synchronous `stats.save()` from LLM call hot path
+
+Closes #{N}
+
+## Test plan
+- [x] `TestBuildPromptWithFiles_StatFirst*` — stat-first size rejection
+- [x] `TestFlushIfDirty_*` — dirty flag write/skip/clear behavior
+- [x] `TestStartSaver_FlushesOnStop` — final flush on stop()
+- [x] `TestStartSaver_FlushesOnTick` — periodic save on ticker
+- [x] `TestStartSaver_StopIdempotent` — double stop() no panic
+EOF
+)"
+```

--- a/docs/superpowers/specs/2026-05-04-debounce-and-stat-first-design.md
+++ b/docs/superpowers/specs/2026-05-04-debounce-and-stat-first-design.md
@@ -1,0 +1,148 @@
+# §1 Debounce Save + §5 Stat-First — Design Spec
+
+**Date:** 2026-05-04
+**Scope:** `cmd/mcp-local-llm/main.go` (§1), `internal/llm/client.go` (§5)
+
+---
+
+## §5 — buildPromptWithFiles: stat-first (simpler, covered first)
+
+### Problem
+`buildPromptWithFiles` calls `os.ReadFile` for every file before checking the total size limit. A single large file is fully read into memory before being rejected.
+
+### Design
+
+Replace the current single-pass read-then-check with a 2-pass approach:
+
+**Pass 1 — stat only:**
+```go
+for i, path := range files {
+    info, err := os.Stat(path)
+    if err != nil {
+        if os.IsNotExist(err) { return "", fmt.Errorf("input_files[%d]: file not found: %s", i, path) }
+        return "", fmt.Errorf("input_files[%d]: stat failed: %w", i, err)
+    }
+    total += info.Size()
+    if maxBytes > 0 && total > int64(maxBytes) {
+        return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
+            "Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
+    }
+}
+```
+
+**Pass 2 — read all (only if pass 1 passes):**
+```go
+for i, path := range files {
+    data, err := os.ReadFile(path)
+    // permission check, etc.
+}
+```
+
+### Error message compatibility
+- `"file not found"` error text preserved (existing tests pass unchanged)
+- `"exceeds limit"` error text preserved (existing tests pass unchanged)
+- Adds `"stat failed"` for new stat error path (not currently tested)
+
+---
+
+## §1 — usage.json Debounced Save + Graceful Shutdown
+
+### Problem
+`stats.save(usagePath)` is called synchronously on every LLM call with error ignored (`_ =`). Under concurrent calls, the mutex is released before file I/O, risking a race. Even without concurrency, blocking the response path on disk I/O is unnecessary.
+
+### Design
+
+#### `usageStats` changes
+Add a `dirty` flag (mutex-protected):
+
+```go
+type usageStats struct {
+    mu               sync.Mutex
+    dirty            bool
+    TotalCalls       int `json:"total_calls"`
+    PromptTokens     int `json:"prompt_tokens"`
+    CompletionTokens int `json:"completion_tokens"`
+    TotalTokens      int `json:"total_tokens"`
+}
+```
+
+`add()` sets `dirty = true`. `save()` clears `dirty = false` after successful write (inside a separate lock).
+
+#### `startSaver` function
+```go
+func startSaver(stats *usageStats, path string, interval time.Duration) (stop func()) {
+    quit := make(chan struct{})
+    go func() {
+        t := time.NewTicker(interval)
+        defer t.Stop()
+        for {
+            select {
+            case <-t.C:
+                stats.flushIfDirty(path)
+            case <-quit:
+                stats.flushIfDirty(path) // final flush on stop
+                return
+            }
+        }
+    }()
+    var once sync.Once
+    return func() { once.Do(func() { close(quit) }) }
+}
+```
+
+`flushIfDirty` checks `dirty` under lock and calls `save()` only when true.
+
+#### `main()` changes
+1. Call `stop := startSaver(stats, usagePath, 30*time.Second)` after loading stats
+2. Register `signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)`
+3. Run `session.Wait()` in a goroutine; block with select on session done or signal:
+```go
+sigCh := make(chan os.Signal, 1)
+signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+done := make(chan error, 1)
+go func() { done <- session.Wait() }()
+select {
+case err := <-done:
+    if err != nil { log.Printf("session error: %v", err) }
+case <-sigCh:
+}
+stop()
+```
+4. **Remove** `_ = stats.save(usagePath)` from the tool handler hot path
+
+#### Shutdown flow
+```
+SIGINT/SIGTERM or session.Wait() returns
+    → select exits
+    → stop() called (sync.Once protected)
+    → saver goroutine receives quit signal
+    → flushIfDirty() runs final save
+    → main() exits
+```
+
+### Constants
+```go
+const saverInterval = 30 * time.Second
+```
+
+### Error handling
+`flushIfDirty` logs save errors via `log.Printf` (not fatal). SIGKILL cannot be caught — up to 30s of counts may be lost; acceptable given usage tracking is non-critical.
+
+---
+
+## Testing
+
+### §5
+- Existing tests pass unchanged (error message text preserved)
+- Add: large file (>limit) fails without reading content — verified by checking that `os.ReadFile` is not called (use a file that would panic if read, or check via timing/size)
+- Add: multiple files where only the sum exceeds limit → stat-phase rejection
+
+### §1
+- `startSaver` unit test: mock `flushIfDirty`, verify called on tick and on stop
+- `stop()` flushes immediately: call stop, verify dirty stats were saved
+- Integration: `add()` sets dirty, tick fires, file written with correct counts
+
+## Out of scope
+- SIGKILL protection (not catchable)
+- Configurable save interval (hardcoded 30s constant)
+- Per-call save removed entirely (no fallback)

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -202,37 +202,37 @@ func buildPromptWithFiles(prompt string, files []string, maxBytes int) (string, 
 	if len(files) == 0 {
 		return prompt, nil
 	}
-	type fileData struct {
-		path    string
-		content []byte
-	}
-	var total int
-	loaded := make([]fileData, 0, len(files))
+	// Pass 1: stat only — reject before reading if total size exceeds limit
+	var total int64
 	for i, path := range files {
-		data, err := os.ReadFile(path)
+		info, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				return "", fmt.Errorf("input_files[%d]: file not found: %s", i, path)
 			}
+			return "", fmt.Errorf("input_files[%d]: stat failed: %w", i, err)
+		}
+		total += info.Size()
+		if maxBytes > 0 && total > int64(maxBytes) {
+			return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
+				"Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
+		}
+	}
+	// Pass 2: read all files (size already validated)
+	var sb strings.Builder
+	sb.WriteString(prompt)
+	for i, path := range files {
+		data, err := os.ReadFile(path)
+		if err != nil {
 			if os.IsPermission(err) {
 				return "", fmt.Errorf("input_files[%d]: permission denied: %s", i, path)
 			}
 			return "", fmt.Errorf("input_files[%d]: read failed: %w", i, err)
 		}
-		total += len(data)
-		if maxBytes > 0 && total > maxBytes {
-			return "", fmt.Errorf("input_files total size (%d bytes) exceeds limit (%d bytes). "+
-				"Reduce file count or set LOCAL_LLM_MAX_INPUT_BYTES to increase limit.", total, maxBytes)
-		}
-		loaded = append(loaded, fileData{path: path, content: data})
-	}
-	var sb strings.Builder
-	sb.WriteString(prompt)
-	for _, f := range loaded {
 		sb.WriteString("\n\n[file: ")
-		sb.WriteString(f.path)
+		sb.WriteString(path)
 		sb.WriteString("]\n")
-		sb.Write(f.content)
+		sb.Write(data)
 	}
 	result := sb.String()
 	if len(result) > 0 && result[len(result)-1] != '\n' {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -513,3 +513,39 @@ func TestCall_ContextCancelledDuringRetry(t *testing.T) {
 		t.Errorf("expected context or 503 error, got: %v", err)
 	}
 }
+
+func TestBuildPromptWithFiles_StatFirstRejectsBeforeRead(t *testing.T) {
+	dir := t.TempDir()
+	large := filepath.Join(dir, "large.txt")
+	if err := os.WriteFile(large, []byte(strings.Repeat("x", 200)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := buildPromptWithFiles("prompt", []string{large}, 50)
+	if err == nil {
+		t.Fatal("expected error when single file exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected 'exceeds limit', got: %v", err)
+	}
+}
+
+func TestBuildPromptWithFiles_StatFirstSumExceedsLimit(t *testing.T) {
+	dir := t.TempDir()
+	f1 := filepath.Join(dir, "a.txt")
+	f2 := filepath.Join(dir, "b.txt")
+	if err := os.WriteFile(f1, []byte(strings.Repeat("a", 60)), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(f2, []byte(strings.Repeat("b", 60)), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := buildPromptWithFiles("prompt", []string{f1, f2}, 100)
+	if err == nil {
+		t.Fatal("expected error when combined size exceeds limit")
+	}
+	if !strings.Contains(err.Error(), "exceeds limit") {
+		t.Errorf("expected 'exceeds limit', got: %v", err)
+	}
+}

--- a/scripts/tts_iu.py
+++ b/scripts/tts_iu.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""IU voice TTS via local vllm-mlx OpenAI-compatible /v1/audio/speech.
+
+Uses chatterbox-multilingual + voice iu + lang_code ko.
+Respects LOCAL_LLM_BASE_URL (default http://localhost:8000).
+
+Example:
+  ./scripts/tts_iu.py "안녕하세요." -o out.wav
+  ./scripts/tts_iu.py -f speech.txt -o out.wav
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_BASE = os.environ.get("LOCAL_LLM_BASE_URL", "http://localhost:8000").rstrip("/")
+MAX_INPUT_CHARS = 4096  # server default in many builds; see docs/VLLM_API.md
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="TTS with IU voice (Korean, chatterbox-multilingual).")
+    g = p.add_mutually_exclusive_group(required=True)
+    g.add_argument("text", nargs="?", help="Text to synthesize")
+    g.add_argument("-f", "--file", metavar="PATH", help="Read text from UTF-8 file")
+    p.add_argument(
+        "-o",
+        "--output",
+        default="iu_tts.wav",
+        metavar="PATH",
+        help="Output WAV path (default: iu_tts.wav)",
+    )
+    p.add_argument(
+        "--base-url",
+        default=DEFAULT_BASE,
+        help=f"API base URL (default: env LOCAL_LLM_BASE_URL or {DEFAULT_BASE!r})",
+    )
+    args = p.parse_args()
+
+    if args.file:
+        with open(args.file, encoding="utf-8") as fp:
+            text = fp.read()
+        if text.startswith("\ufeff"):
+            text = text[1:]
+    else:
+        text = args.text or ""
+
+    text = text.strip()
+    if not text:
+        print("error: empty input", file=sys.stderr)
+        return 1
+    if len(text) > MAX_INPUT_CHARS:
+        print(
+            f"error: input is {len(text)} characters (max {MAX_INPUT_CHARS}); split or shorten",
+            file=sys.stderr,
+        )
+        return 1
+
+    body = json.dumps(
+        {
+            "model": "chatterbox-multilingual",
+            "input": text,
+            "voice": "iu",
+            "response_format": "wav",
+            "lang_code": "ko",
+        },
+        ensure_ascii=False,
+    ).encode("utf-8")
+
+    url = f"{args.base_url.rstrip('/')}/v1/audio/speech"
+    req = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={"Content-Type": "application/json; charset=utf-8"},
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=600) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        err = e.read().decode("utf-8", errors="replace")
+        print(f"HTTP {e.code}: {err}", file=sys.stderr)
+        return 1
+    except urllib.error.URLError as e:
+        print(f"request failed: {e}", file=sys.stderr)
+        return 1
+
+    if raw[:4] != b"RIFF":
+        print("error: response is not a WAV file (check server logs)", file=sys.stderr)
+        return 1
+
+    out = args.output
+    with open(out, "wb") as fp:
+        fp.write(raw)
+    print(f"wrote {len(raw)} bytes to {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

### §5 — stat-first in buildPromptWithFiles
- Replace single read-then-check loop with 2-pass: `os.Stat` size sum first, `os.ReadFile` only if within limit
- Avoids reading large files that will be rejected anyway
- Error messages unchanged (existing tests unaffected)

### §1 — Debounce usage.json save
- Add `dirty` flag to `usageStats`; `add()` sets it, `flushIfDirty()` clears after write
- `startSaver` ticker goroutine flushes every 30s when dirty; `sync.Once`-protected stop
- `main()` registers `SIGINT`/`SIGTERM`; either signal or session end triggers `stop()` → final flush
- Remove synchronous `stats.save()` from LLM call hot path

Closes #23

## Test plan
- [x] `TestBuildPromptWithFiles_StatFirst*` — stat-first size rejection
- [x] `TestFlushIfDirty_*` — dirty flag write/skip/clear behavior
- [x] `TestStartSaver_FlushesOnStop` — final flush on stop()
- [x] `TestStartSaver_FlushesOnTick` — periodic save on ticker
- [x] `TestStartSaver_StopIdempotent` — double stop() no panic