### PR TITLE
feat: add tool calling support to call_local_llm (Pattern A)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,6 +22,11 @@ Break-even point: ~280 chars (~70 tokens) of expected output. Below this, tool c
 - Multi-step code analysis with continuous reasoning
 - Refusal / judgment calls based on user intent
 
+### Tool calling (Pattern A)
+`call_local_llm` supports tool calling: pass `tools` (JSON string of OpenAI tool schemas) and optionally `tool_choice`. If the local LLM responds with a `tool_calls` JSON array instead of text, execute the tools, then call again with `messages` (JSON string of full conversation history including tool results). Repeat until plain text is returned. The MCP server is stateless — Claude orchestrates the loop.
+
+Use when: multi-step file analysis, codebase exploration, or any task where the local LLM should decide what to read/run next.
+
 ### Calling conventions
 - Omit `max_tokens` unless a specific limit is needed (server default 32768)
 - For drafts (PR/commit/issue), pass concrete context in `prompt` — changes summary and key file paths, not entire diffs

--- a/README.md
+++ b/README.md
@@ -76,10 +76,41 @@ Calls the local LLM and returns its response as plain text. Each response includ
 | `model` | no | Override the default model for this call |
 | `max_tokens` | no | Override the default token limit for this call |
 | `filter_thinking` | no | Override server-level thinking block filtering for this call (`true` = filter, `false` = keep). Omit to use the server default (`LOCAL_LLM_FILTER_THINKING`). |
-| `images` | no | List of images to send with the prompt. Each entry can be a file path, an `https://` URL, or a `data:image/...;base64,...` URI. Mixed formats allowed. Maximum per call is controlled by `LOCAL_LLM_MAX_IMAGES`. |
+| `images` | no | List of images to send with the prompt. Each entry can be a file path, an `http://` or `https://` URL, or a `data:image/...;base64,...` URI. Mixed formats allowed. Maximum per call is controlled by `LOCAL_LLM_MAX_IMAGES`. |
 | `input_files` | no | List of file paths for the MCP server to read and include in the prompt. File contents are appended after `prompt`, keeping them out of Claude's context window. All paths must be within `LOCAL_LLM_WORK_DIR`. Combined size is limited by `LOCAL_LLM_MAX_INPUT_BYTES`. |
 | `output_file` | no | File path to write the LLM response to. When set, returns `"saved N bytes to path"` instead of the full response, keeping large outputs out of Claude's context window. Must be within `LOCAL_LLM_WORK_DIR`. Parent directory must exist. |
 | `append` | no | When `true`, appends to an existing `output_file` instead of overwriting. Ignored when `output_file` is not set. Default: `false`. |
+| `tools` | no | JSON string of tool schemas in [OpenAI tool format](https://platform.openai.com/docs/guides/function-calling). Example: `'[{"type":"function","function":{"name":"read_file","description":"...","parameters":{...}}}]'`. When the model decides to call a tool, the response is a JSON array string of `tool_calls` instead of plain text. |
+| `tool_choice` | no | Controls tool selection: `"auto"` (model decides), `"none"` (disable), or a JSON object string `'{"type":"function","function":{"name":"toolName"}}'` to force a specific tool. |
+| `messages` | no | Full conversation history as a JSON string (OpenAI `messages` array). When provided, `prompt`, `system`, `images`, and `input_files` are ignored. Used for multi-turn calls: after receiving `tool_calls`, execute the tools and call again with the accumulated message history including tool results. |
+
+**Tool calling (Pattern A — Claude orchestrates)**
+
+The local LLM can call tools through a multi-turn loop where Claude acts as the executor:
+
+1. Call with `tools` (and optionally `tool_choice`). The local LLM may respond with a `tool_calls` JSON array instead of plain text.
+2. Parse the returned JSON, execute each tool call (e.g. `Read`, `Bash`), collect results.
+3. Call again with `messages` containing the full history: original user message → assistant `tool_calls` → tool results.
+4. Repeat until the local LLM returns plain text (no `tool_calls`).
+
+```
+// First call — tools is a JSON string
+prompt: "Analyze main.go"
+tools:  '[{"type":"function","function":{"name":"Read","description":"Read a file","parameters":{"type":"object","properties":{"path":{"type":"string"}},"required":["path"]}}}]'
+
+// Response (tool_calls JSON string — execute these tools, then call again)
+[{"id":"tc1","type":"function","function":{"name":"Read","arguments":"{\"path\":\"main.go\"}"}}]
+
+// Second call — messages is a JSON string with full history
+messages: '[
+  {"role":"user","content":"Analyze main.go"},
+  {"role":"assistant","tool_calls":[{"id":"tc1","type":"function","function":{"name":"Read","arguments":"{\"path\":\"main.go\"}"}}]},
+  {"role":"tool","content":"package main...","tool_call_id":"tc1"}
+]'
+tools: '[...]'
+```
+
+The MCP server is stateless — loop orchestration is handled entirely by Claude.
 
 **Recommended use cases**
 

--- a/cmd/mcp-local-llm/main.go
+++ b/cmd/mcp-local-llm/main.go
@@ -199,7 +199,10 @@ func main() {
 		Description: "ALWAYS use this instead of generating text yourself for: summaries, " +
 			"translations, PR/commit/issue drafts, release notes, documentation, " +
 			"and any response over ~70 tokens. Cheaper than Claude. " +
-			"Supports images (file path, https:// URL, data:image/ URI).",
+			"Supports images (file path, http:// or https:// URL, data:image/ URI). " +
+			"Supports tool calling: pass 'tools' (OpenAI tool schema array) and optionally 'tool_choice'. " +
+			"If the local LLM responds with tool_calls, returns a JSON array string — " +
+			"execute the tools, then call again with 'messages' containing the full conversation history including tool results.",
 	}, func(ctx context.Context, req *mcp.CallToolRequest, in *llm.Input) (*mcp.CallToolResult, any, error) {
 		if in.Prompt == "" {
 			return &mcp.CallToolResult{

--- a/docs/improvements-llm-client-mcp.md
+++ b/docs/improvements-llm-client-mcp.md
@@ -4,21 +4,9 @@
 
 ---
 
-## 1. `usage.json` 매 호출 디스크 저장 — 핵심 경로의 불필요한 I/O
+## ~~1. `usage.json` 매 호출 디스크 저장 — 핵심 경로의 불필요한 I/O~~ ✅ 완료
 
-**위치:** [`cmd/mcp-local-llm/main.go`](../cmd/mcp-local-llm/main.go) — `call_local_llm` 툴 핸들러에서 매 LLM 호출마다 `stats.save(usagePath)` 호출.
-
-**현재 동작:** `WriteFile(.tmp)` + `Rename` 등이 응답 반환 직전에 동기 실행된다.
-
-**문제:**
-
-- 동시 호출 시 `save()`가 뮤텍스 해제 뒤 파일 I/O를 수행하면, 여러 고루틴이 같은 파일에 경쟁적으로 쓰기 → **마지막 쓰기 승, 카운트 손실 가능**.
-- 핵심 경로에서 저장 오류를 `_`로 무시해 **안전성·관측 가능성**이 낮다.
-
-**개선 방향:**
-
-- **디바운스 / 주기 저장:** 별도 고루틴에서 N초마다, 변경이 있을 때만 저장. 툴 핸들러 핵심 경로에서는 `save` 제거.
-- **Graceful shutdown:** `signal.Notify(SIGINT/SIGTERM)` 후 마지막 flush. 디바운스 도입 시 프로세스 종료 시 통계 유실 방지에 필요.
+`startSaver` (30초 ticker + `flushIfDirty`)로 디바운스 저장 구현. 툴 핸들러에서 `save()` 직접 호출 제거. SIGINT/SIGTERM graceful shutdown 포함.
 
 ---
 
@@ -36,17 +24,9 @@
 
 ---
 
-## 3. 트랜션트 오류 재시도 부재 — 신뢰성
+## ~~3. 트랜션트 오류 재시도 부재 — 신뢰성~~ ✅ 완료
 
-**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `http.Client.Do` 실패 또는 5xx 응답 시 즉시 에러 반환.
-
-**문제:** vllm-mlx가 일시적으로 불안정할 때(5xx, KV/OOM 직후, 연결 거절 등) MCP 사용자에게 바로 실패로 전달된다.
-
-**개선 방향:**
-
-- **Bounded retry:** 5xx, 일시적 `net.Error`, `connection refused` 등에 한해 최대 2회, 200ms → 1s 정도 백오프.
-- POST이지만 동일 프롬프트 재시도는 운영상 허용 가능한 경우가 많다(출력은 원래 비결정적).
-- **`context.Context` 취소** 시 재시도 중단.
+`maxRetries=2`, `retryDelays=[200ms, 1s]`, `isRetryable()` 구현. 5xx·`net.Error`·`connection refused` 대상, `context.Context` 취소 시 중단.
 
 ---
 
@@ -64,16 +44,9 @@
 
 ---
 
-## 5. `buildPromptWithFiles` — 한도 초과로 거절될 파일도 전부 읽음
+## ~~5. `buildPromptWithFiles` — 한도 초과로 거절될 파일도 전부 읽음~~ ✅ 완료
 
-**위치:** [`internal/llm/client.go`](../internal/llm/client.go) — `buildPromptWithFiles`: `os.ReadFile` 후 누적 바이트가 `maxBytes`를 넘으면 에러.
-
-**문제:** 단일 대용량 파일이면 **전부 읽은 뒤**에야 초과를 감지할 수 있어 I/O·메모리 낭비.
-
-**개선 방향:**
-
-- **1패스:** `os.Stat`으로 각 파일 크기 합산 → `maxBytes` 초과 시 즉시 에러.
-- **2패스:** 통과한 경우에만 `os.ReadFile`로 내용 로드.
+2-pass 구조 도입: Pass 1에서 `os.Stat` 합산 → 초과 시 즉시 에러, Pass 2에서 실제 `os.ReadFile`.
 
 ---
 
@@ -184,89 +157,11 @@
 
 ---
 
-## 10. Tool Calling 지원 — 로컬 LLM에게 Claude 도구 위임
+## ~~10. Tool Calling 지원 — 로컬 LLM에게 Claude 도구 위임~~ ✅ 완료 (패턴 A)
 
-**배경:** vllm-mlx 서버는 OpenAI 호환 `tools` / `tool_choice` 파라미터를 완전히 지원한다(실험 확인). 현재 `call_local_llm`은 텍스트 in/out만 처리하며, `chatResponse.choices[0].message.tool_calls`를 무시한다. 이를 활성화하면 아래 세 가지 패턴으로 **Claude 토큰을 대폭 절약**할 수 있다.
+패턴 A (Manager-Worker) 구현 완료. `Input`에 `Tools`, `ToolChoice`, `Messages` 필드 추가. `chatResponse`에 `tool_calls` 파싱 추가. `Call()` 에서 `tool_calls` 있으면 JSON 문자열 반환 — Claude가 루프 오케스트레이션 담당. `messages` 제공 시 멀티턴 히스토리 그대로 전달. 하위 호환성 유지 (`tools` 없으면 기존 동작 동일).
 
-### 세 가지 위임 패턴
-
-**패턴 A — Manager-Worker (로컬 LLM이 툴 선택·판단)**
-
-로컬 LLM이 어떤 툴을 어떤 순서로 호출할지 결정하고, Claude는 툴 실행 릴레이만 담당한다.
-
-```
-Claude → call_local_llm(prompt, tools=[Read, Bash, Glob])
-로컬LLM → tool_calls: [Read("main.go"), ...]
-Claude  → 툴 실행 후 call_local_llm(messages=[...tool_result...])
-로컬LLM → 최종 텍스트
-```
-
-- **절약 효과:** 파일 20개 분석 기준 Claude 토큰 약 94% 감소 (41,500 → 2,300)
-- **적합한 태스크:** 반복 파일 읽기, 코드베이스 탐색, 멀티스텝 분석
-
-**패턴 B — Decision-Secretary (Claude가 툴 지정, 로컬 LLM이 인자 생성+합성)**
-
-`tool_choice`로 Claude가 어떤 툴을 쓸지 지시하고, 로컬 LLM은 인자 생성과 최종 답변 합성을 담당한다.
-
-```
-Claude → call_local_llm(prompt, tools=[get_weather], tool_choice="get_weather")
-로컬LLM → tool_calls: [get_weather({"city":"서울"})]
-Claude  → 툴 실행 후 결과 전달
-로컬LLM → 최종 합성 텍스트
-```
-
-- **절약 효과:** 단순 태스크 기준 약 63% 감소
-- **적합한 태스크:** 특정 데이터 1회 조회 + 긴 합성 출력
-
-**패턴 C — Researcher-Writer (Claude가 수집, 로컬 LLM이 보고서 작성)**
-
-Claude가 WebSearch·Bash·Read 등 자신의 툴로 데이터를 수집하고, 결과를 `messages`에 담아 로컬 LLM에 전달하면 로컬 LLM이 합성만 담당한다.
-
-```
-Claude  → WebSearch, Read(코드파일들) 실행
-Claude  → call_local_llm(messages=[수집된_데이터], prompt="보고서 작성")
-로컬LLM → 최종 보고서
-```
-
-- **절약 효과:** 보고서 작성 output 토큰 제거 (Claude output이 가장 비쌈)
-- **적합한 태스크:** 조사+합성 분리 가능한 장문 보고서, 릴리즈 노트 분석
-
-### 구현 범위
-
-**`internal/llm/client.go`**
-
-```go
-// Input에 추가
-Tools      []json.RawMessage `json:"tools,omitempty"`
-ToolChoice interface{}       `json:"tool_choice,omitempty"`
-Messages   []ChatMessage     `json:"messages,omitempty"` // 멀티턴
-
-// chatResponse에 추가
-type toolCall struct {
-    ID       string `json:"id"`
-    Type     string `json:"type"`
-    Function struct {
-        Name      string `json:"name"`
-        Arguments string `json:"arguments"`
-    } `json:"function"`
-}
-// choices[0].message.tool_calls 파싱
-
-// Call() 반환값 변경
-// tool_calls가 있으면 JSON 문자열로 반환 (Claude가 루프 처리)
-```
-
-**`cmd/mcp-local-llm/main.go`**
-
-- `call_local_llm` 툴 설명에 tool calling 사용법 추가
-- tool_calls 응답 시 JSON 그대로 반환 (Claude가 파싱 후 다음 단계 결정)
-
-### 주의사항
-
-- **멀티턴 루프는 Claude가 담당**: MCP 서버는 무상태(stateless) 유지. 루프 오케스트레이션은 Claude가 `call_local_llm`을 반복 호출하는 방식.
-- **`Messages` 파라미터**: system/user/assistant/tool 역할 지원 필요. `Input.System`과 충돌하지 않도록 설계.
-- **하위 호환성**: `tools` 없이 호출하면 기존과 동일하게 동작해야 함.
-- **Gemma thinking 블록**: tool_calls 응답에도 thinking 블록이 붙을 수 있어 `FilterThinking` 적용 필요.
+패턴 B·C는 동일 구현으로 이미 동작함 (`tool_choice` 파라미터, `messages` 파라미터 각각 활용).
 
 ---
 
@@ -277,6 +172,6 @@ type toolCall struct {
 | MCP 툴, usage 저장 | `cmd/mcp-local-llm/main.go` |
 | HTTP 클라이언트, 프롬프트/이미지/필터 | `internal/llm/client.go` |
 | STT·TTS HTTP (예정) | `internal/llm/` 신규 또는 `client.go` 인접 패키지 — §9 |
-| Tool calling 지원 (예정) | `internal/llm/client.go`, `cmd/mcp-local-llm/main.go` — §10 |
+| Tool calling 지원 | `internal/llm/client.go`, `cmd/mcp-local-llm/main.go` — §10 ✅ |
 | 로컬 오디오 API 스펙 | `docs/VLLM_API.md` |
 | 기존 단위 테스트 | `internal/llm/client_test.go` |

--- a/internal/llm/client.go
+++ b/internal/llm/client.go
@@ -53,16 +53,28 @@ type imageURL struct {
 	URL string `json:"url"`
 }
 
+type toolCall struct {
+	ID       string `json:"id"`
+	Type     string `json:"type"`
+	Function struct {
+		Name      string `json:"name"`
+		Arguments string `json:"arguments"`
+	} `json:"function"`
+}
+
 type Input struct {
-	Prompt         string   `json:"prompt"                    jsonschema:"LLM에 전달할 사용자 메시지,required"`
-	System         string   `json:"system,omitempty"          jsonschema:"시스템 프롬프트 (선택사항)"`
-	Model          string   `json:"model,omitempty"           jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
-	MaxTokens      int      `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (생략 시 서버 기본값 사용)"`
-	FilterThinking *bool    `json:"filter_thinking,omitempty" jsonschema:"thinking 블록 필터링 여부 (true=필터, false=유지). 생략 시 서버 기본값(LOCAL_LLM_FILTER_THINKING) 적용"`
-	Images         []string `json:"images,omitempty"          jsonschema:"이미지 목록 (파일 경로·URL·base64 data URI 혼합 가능)"`
-	InputFiles     []string `json:"input_files,omitempty"     jsonschema:"읽어서 프롬프트에 포함할 파일 경로 목록. MCP 서버가 직접 읽어 Claude 컨텍스트 절약"`
-	OutputFile     string   `json:"output_file,omitempty"     jsonschema:"결과를 저장할 파일 경로. 지정 시 저장 완료 메시지만 반환 (Claude 컨텍스트 절약)"`
-	Append         bool     `json:"append,omitempty"          jsonschema:"true이면 output_file에 이어쓰기. 기본값 false (덮어쓰기)"`
+	Prompt         string            `json:"prompt"                    jsonschema:"LLM에 전달할 사용자 메시지,required"`
+	System         string            `json:"system,omitempty"          jsonschema:"시스템 프롬프트 (선택사항)"`
+	Model          string            `json:"model,omitempty"           jsonschema:"사용할 모델 이름 (기본값: gemma-4-26b-a4b-it-4bit)"`
+	MaxTokens      int               `json:"max_tokens,omitempty"      jsonschema:"최대 출력 토큰 수 (생략 시 서버 기본값 사용)"`
+	FilterThinking *bool             `json:"filter_thinking,omitempty" jsonschema:"thinking 블록 필터링 여부 (true=필터, false=유지). 생략 시 서버 기본값(LOCAL_LLM_FILTER_THINKING) 적용"`
+	Images         []string          `json:"images,omitempty"          jsonschema:"이미지 목록 (파일 경로·URL·base64 data URI 혼합 가능)"`
+	InputFiles     []string          `json:"input_files,omitempty"     jsonschema:"읽어서 프롬프트에 포함할 파일 경로 목록. MCP 서버가 직접 읽어 Claude 컨텍스트 절약"`
+	OutputFile     string            `json:"output_file,omitempty"     jsonschema:"결과를 저장할 파일 경로. 지정 시 저장 완료 메시지만 반환 (Claude 컨텍스트 절약)"`
+	Append         bool              `json:"append,omitempty"          jsonschema:"true이면 output_file에 이어쓰기. 기본값 false (덮어쓰기)"`
+	Tools      string `json:"tools,omitempty"       jsonschema:"로컬 LLM에 제공할 툴 스키마 배열 (JSON 문자열). 예: [{\"type\":\"function\",\"function\":{\"name\":\"read_file\",\"description\":\"...\",\"parameters\":{...}}}]. 응답에 tool_calls가 있으면 JSON 배열 문자열로 반환됨"`
+	ToolChoice string `json:"tool_choice,omitempty" jsonschema:"툴 선택 방식: \"auto\", \"none\", 또는 {\"type\":\"function\",\"function\":{\"name\":\"toolName\"}}"`
+	Messages   string `json:"messages,omitempty"    jsonschema:"멀티턴 메시지 배열 (JSON 문자열). OpenAI messages format. 제공 시 prompt/system/images/input_files 무시. tool_calls 응답 후 재호출 시 전체 대화 히스토리 전달"`
 }
 
 type chatMessage struct {
@@ -71,9 +83,11 @@ type chatMessage struct {
 }
 
 type chatRequest struct {
-	Model     string        `json:"model"`
-	Messages  []chatMessage `json:"messages"`
-	MaxTokens *int          `json:"max_tokens,omitempty"`
+	Model      string            `json:"model"`
+	Messages   interface{}       `json:"messages"`
+	MaxTokens  *int              `json:"max_tokens,omitempty"`
+	Tools      []map[string]interface{} `json:"tools,omitempty"`
+	ToolChoice interface{}       `json:"tool_choice,omitempty"`
 }
 
 type Usage struct {
@@ -85,7 +99,8 @@ type Usage struct {
 type chatResponse struct {
 	Choices []struct {
 		Message struct {
-			Content string `json:"content"`
+			Content   string     `json:"content"`
+			ToolCalls []toolCall `json:"tool_calls,omitempty"`
 		} `json:"message"`
 	} `json:"choices"`
 	Error *struct {
@@ -269,16 +284,6 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 		}
 	}
 
-	// Validate and resolve input file paths against work directory
-	inputFiles := make([]string, len(in.InputFiles))
-	for i, f := range in.InputFiles {
-		p, err := validatePath(f, c.WorkDir)
-		if err != nil {
-			return "", Usage{}, fmt.Errorf("input_files[%d]: %w", i, err)
-		}
-		inputFiles[i] = p
-	}
-
 	// Validate and resolve output file path against work directory
 	outputFile := in.OutputFile
 	if in.OutputFile != "" {
@@ -289,27 +294,66 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 		outputFile = p
 	}
 
-	prompt := in.Prompt
-	if len(inputFiles) > 0 {
-		var err error
-		prompt, err = buildPromptWithFiles(in.Prompt, inputFiles, c.MaxInputBytes)
-		if err != nil {
-			return "", Usage{}, err
+	// Parse tools JSON string → typed slice for chatRequest
+	var tools []map[string]interface{}
+	if in.Tools != "" {
+		if err := json.Unmarshal([]byte(in.Tools), &tools); err != nil {
+			return "", Usage{}, fmt.Errorf("tools: invalid JSON: %w", err)
 		}
 	}
 
-	messages := []chatMessage{}
-	if in.System != "" {
-		messages = append(messages, chatMessage{Role: "system", Content: in.System})
-	}
-	if len(in.Images) > 0 {
-		parts, err := buildImageContent(prompt, in.Images, c.MaxImages)
-		if err != nil {
-			return "", Usage{}, err
+	// Parse tool_choice: try as JSON object first, fall back to plain string
+	var toolChoice interface{}
+	if in.ToolChoice != "" {
+		var obj interface{}
+		if err := json.Unmarshal([]byte(in.ToolChoice), &obj); err == nil {
+			toolChoice = obj
+		} else {
+			toolChoice = in.ToolChoice
 		}
-		messages = append(messages, chatMessage{Role: "user", Content: parts})
+	}
+
+	// Build messages: parse JSON string when provided, else construct from prompt/system/images/input_files
+	var messages interface{}
+	if in.Messages != "" {
+		var parsed []map[string]interface{}
+		if err := json.Unmarshal([]byte(in.Messages), &parsed); err != nil {
+			return "", Usage{}, fmt.Errorf("messages: invalid JSON: %w", err)
+		}
+		messages = parsed
 	} else {
-		messages = append(messages, chatMessage{Role: "user", Content: prompt})
+		inputFiles := make([]string, len(in.InputFiles))
+		for i, f := range in.InputFiles {
+			p, err := validatePath(f, c.WorkDir)
+			if err != nil {
+				return "", Usage{}, fmt.Errorf("input_files[%d]: %w", i, err)
+			}
+			inputFiles[i] = p
+		}
+
+		prompt := in.Prompt
+		if len(inputFiles) > 0 {
+			var err error
+			prompt, err = buildPromptWithFiles(in.Prompt, inputFiles, c.MaxInputBytes)
+			if err != nil {
+				return "", Usage{}, err
+			}
+		}
+
+		chatMsgs := []chatMessage{}
+		if in.System != "" {
+			chatMsgs = append(chatMsgs, chatMessage{Role: "system", Content: in.System})
+		}
+		if len(in.Images) > 0 {
+			parts, err := buildImageContent(prompt, in.Images, c.MaxImages)
+			if err != nil {
+				return "", Usage{}, err
+			}
+			chatMsgs = append(chatMsgs, chatMessage{Role: "user", Content: parts})
+		} else {
+			chatMsgs = append(chatMsgs, chatMessage{Role: "user", Content: prompt})
+		}
+		messages = chatMsgs
 	}
 
 	model := in.Model
@@ -325,7 +369,13 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 		maxTokens = &v
 	}
 
-	body, err := json.Marshal(chatRequest{Model: model, Messages: messages, MaxTokens: maxTokens})
+	body, err := json.Marshal(chatRequest{
+		Model:      model,
+		Messages:   messages,
+		MaxTokens:  maxTokens,
+		Tools:      tools,
+		ToolChoice: toolChoice,
+	})
 	if err != nil {
 		return "", Usage{}, fmt.Errorf("marshal failed: %w", err)
 	}
@@ -385,6 +435,15 @@ func (c *Client) Call(ctx context.Context, in *Input) (string, Usage, error) {
 	if len(result.Choices) == 0 {
 		return "", Usage{}, fmt.Errorf("empty response")
 	}
+	// tool_calls 응답이면 JSON 문자열로 반환 — Claude가 파싱 후 실제 툴 실행 및 재호출
+	if len(result.Choices[0].Message.ToolCalls) > 0 {
+		toolCallsJSON, err := json.Marshal(result.Choices[0].Message.ToolCalls)
+		if err != nil {
+			return "", Usage{}, fmt.Errorf("marshal tool_calls: %w", err)
+		}
+		return string(toolCallsJSON), result.Usage, nil
+	}
+
 	content := result.Choices[0].Message.Content
 	filterThinking := c.FilterThinking
 	if in.FilterThinking != nil {

--- a/internal/llm/client_test.go
+++ b/internal/llm/client_test.go
@@ -3,7 +3,9 @@ package llm
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -547,5 +549,181 @@ func TestBuildPromptWithFiles_StatFirstSumExceedsLimit(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "exceeds limit") {
 		t.Errorf("expected 'exceeds limit', got: %v", err)
+	}
+}
+
+func TestCall_WithTools_ReturnsToolCallsJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req map[string]interface{}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			t.Errorf("failed to decode request: %v", err)
+		}
+		if _, ok := req["tools"]; !ok {
+			t.Error("expected 'tools' in request body")
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{"message":{"content":"","tool_calls":[{
+				"id":"tc1","type":"function",
+				"function":{"name":"Read","arguments":"{\"path\":\"main.go\"}"}
+			}]}}],
+			"usage":{}
+		}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+
+	result, _, err := c.Call(context.Background(), &Input{
+		Prompt: "analyze main.go",
+		Tools:  `[{"type":"function","function":{"name":"Read","parameters":{}}}]`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var calls []toolCall
+	if err := json.Unmarshal([]byte(result), &calls); err != nil {
+		t.Fatalf("expected tool_calls JSON, got: %s — parse error: %v", result, err)
+	}
+	if len(calls) != 1 {
+		t.Fatalf("expected 1 tool call, got %d", len(calls))
+	}
+	if calls[0].ID != "tc1" {
+		t.Errorf("expected id 'tc1', got %q", calls[0].ID)
+	}
+	if calls[0].Function.Name != "Read" {
+		t.Errorf("expected function name 'Read', got %q", calls[0].Function.Name)
+	}
+	if calls[0].Function.Arguments != `{"path":"main.go"}` {
+		t.Errorf("unexpected arguments: %s", calls[0].Function.Arguments)
+	}
+}
+
+func TestCall_WithTools_TextResponseReturnsContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"plain answer"}}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+
+	result, _, err := c.Call(context.Background(), &Input{
+		Prompt: "hello",
+		Tools:  `[{"type":"function","function":{"name":"Read","parameters":{}}}]`,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "plain answer" {
+		t.Errorf("expected 'plain answer', got %q", result)
+	}
+}
+
+func TestCall_WithMessages_SendsHistoryDirectly(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"final answer"}}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	messagesJSON := `[
+		{"role":"user","content":"analyze main.go"},
+		{"role":"assistant","tool_calls":[{"id":"tc1","type":"function","function":{"name":"Read","arguments":"{\"path\":\"main.go\"}"}}]},
+		{"role":"tool","content":"package main...","tool_call_id":"tc1"}
+	]`
+
+	result, _, err := c.Call(context.Background(), &Input{
+		Prompt:   "this should be ignored",
+		Messages: messagesJSON,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != "final answer" {
+		t.Errorf("expected 'final answer', got %q", result)
+	}
+
+	var req map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &req); err != nil {
+		t.Fatalf("failed to parse captured request: %v", err)
+	}
+	msgs, ok := req["messages"].([]interface{})
+	if !ok {
+		t.Fatalf("expected messages array in request, got: %T", req["messages"])
+	}
+	if len(msgs) != 3 {
+		t.Errorf("expected 3 messages, got %d", len(msgs))
+	}
+}
+
+func TestCall_ToolCallsSkipsOutputFile(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{
+			"choices":[{"message":{"content":"","tool_calls":[{
+				"id":"tc1","type":"function","function":{"name":"Read","arguments":"{}"}
+			}]}}],
+			"usage":{}
+		}`))
+	}))
+	defer srv.Close()
+
+	dir := t.TempDir()
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, dir)
+	outPath := filepath.Join(dir, "out.txt")
+
+	result, _, err := c.Call(context.Background(), &Input{
+		Prompt:     "hello",
+		OutputFile: outPath,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, statErr := os.Stat(outPath); !os.IsNotExist(statErr) {
+		t.Error("output_file must not be written when tool_calls are returned")
+	}
+	var calls []toolCall
+	if err := json.Unmarshal([]byte(result), &calls); err != nil {
+		t.Fatalf("expected tool_calls JSON, got: %s", result)
+	}
+}
+
+func TestCall_ToolChoiceIncludedInRequest(t *testing.T) {
+	var capturedBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var err error
+		capturedBody, err = io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"choices":[{"message":{"content":"ok"}}],"usage":{}}`))
+	}))
+	defer srv.Close()
+
+	c := NewClient(srv.URL, "test-model", 0, 0, 0, false, 5, 0, t.TempDir())
+	_, _, err := c.Call(context.Background(), &Input{
+		Prompt:     "hello",
+		ToolChoice: "auto",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var req map[string]interface{}
+	if err := json.Unmarshal(capturedBody, &req); err != nil {
+		t.Fatalf("failed to parse captured request: %v", err)
+	}
+	if req["tool_choice"] != "auto" {
+		t.Errorf("expected tool_choice='auto', got: %v", req["tool_choice"])
 	}
 }


### PR DESCRIPTION
## Summary

- `Input` struct에 `Tools`, `ToolChoice`, `Messages` 필드 추가 (JSON 문자열 타입 — MCP 프로토콜이 배열 파라미터를 문자열로 직렬화하기 때문)
- `chatResponse`에 `tool_calls` 파싱 추가, `Call()`에서 tool_calls 있으면 JSON 문자열로 반환
- 멀티턴 루프: `tools` 전달 → `tool_calls` 응답 → Claude가 툴 실행 → `messages`로 재호출 → 최종 텍스트 반환 (MCP 서버는 무상태 유지)
- 신규 단위 테스트 5개, README/CLAUDE.md/개선 문서 업데이트

## Test plan

- [x] `go test ./...` 전체 통과
- [x] 실제 MCP 호출로 패턴 A 전체 루프 동작 확인 (tool_calls 반환 → messages 재호출 → 최종 텍스트)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)